### PR TITLE
Add missing dev dependency to vite

### DIFF
--- a/packages/boilerplates/shared/files/$index.html.ts
+++ b/packages/boilerplates/shared/files/$index.html.ts
@@ -1,0 +1,17 @@
+import { type MaybeContentGetter, type VikeMeta } from "@batijs/core";
+
+export default function createDefaultIndexHtml(_currentContent: MaybeContentGetter, meta: VikeMeta) {
+  if (meta.BATI_MODULES?.some((m) => m.startsWith("framework:"))) return null;
+
+  return `<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>My App</title>
+</head>
+<body>
+<h1>Created with Bâti</h1>
+</body>
+</html>`;
+}

--- a/packages/boilerplates/shared/files/package.json
+++ b/packages/boilerplates/shared/files/package.json
@@ -11,7 +11,8 @@
   "keywords": [],
   "author": "",
   "devDependencies": {
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "vite": "^4.3.9"
   },
   "dependencies": {}
 }

--- a/packages/boilerplates/shared/package.json
+++ b/packages/boilerplates/shared/package.json
@@ -6,8 +6,7 @@
   "type": "module",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "prerelease": "rm -rf ./dist",
-    "build": "mkdir -p ./dist && cp -r ./files ./dist/"
+    "build": "tsup"
   },
   "keywords": [],
   "author": "",

--- a/packages/boilerplates/shared/tsup.config.ts
+++ b/packages/boilerplates/shared/tsup.config.ts
@@ -1,0 +1,3 @@
+import { defineBoilerplateConfig } from "@batijs/tsup";
+
+export default defineBoilerplateConfig();

--- a/packages/build/src/exec.ts
+++ b/packages/build/src/exec.ts
@@ -37,7 +37,8 @@ export async function* walk(dir: string): AsyncGenerator<string> {
   }
 }
 
-function transformFileAfterExec(filepath: string, fileContent: unknown): string {
+function transformFileAfterExec(filepath: string, fileContent: unknown): string | null {
+  if (fileContent === undefined || fileContent === null) return null;
   const parsed = path.parse(filepath);
   const ext = parsed.ext || parsed.name;
   switch (ext) {
@@ -46,6 +47,7 @@ function transformFileAfterExec(filepath: string, fileContent: unknown): string 
     case ".tsx":
     case ".jsx":
     case ".env":
+    case ".html":
       return fileContent as string;
     case ".json":
       return JSON.stringify(fileContent, null, 2);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,8 +25,7 @@
     "node-fetch": "^3.3.1",
     "tsup": "^6.7.0",
     "typescript": "^5.1.3",
-    "vitest": "^0.32.0",
-    "wait-for-localhost": "^4.0.1"
+    "vitest": "^0.32.0"
   },
   "dependencies": {
     "@batijs/core": "workspace:*"

--- a/packages/cli/tests/empty.spec.ts
+++ b/packages/cli/tests/empty.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vitest";
+import { prepare } from "./utils";
+
+describe.concurrent("empty", () => {
+  const { fetch } = prepare([""]);
+
+  test("home", async () => {
+    const res = await fetch("/");
+    expect(res.status).toBe(200);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,9 +357,6 @@ importers:
       vitest:
         specifier: ^0.32.0
         version: 0.32.0
-      wait-for-localhost:
-        specifier: ^4.0.1
-        version: 4.0.1
 
   packages/core:
     devDependencies:
@@ -7744,11 +7741,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /wait-for-localhost@4.0.1:
-    resolution: {integrity: sha512-/q7fnGj3ATD4myCqlH3ZB/soX3cFZAztMvZgxOv0bZ7+8MsBUQrxIVrUkLsmro0qZAI5L9/QLGhJ0RsTfCmIbQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /web-streams-polyfill@3.2.1:


### PR DESCRIPTION
By default (without --solid flag), bati scaffolds a package.json with dev/build/preview scripts running vite, so we need to install vite for these scripts to work

Should we also ship a dummy `index.html`?