### PR TITLE
[cli/tests] Log execa's timeout or failure with timestamps

### DIFF
--- a/packages/cli/tests/processUtils.ts
+++ b/packages/cli/tests/processUtils.ts
@@ -1,0 +1,83 @@
+import {
+  execa as execaOrig,
+  type ExecaChildProcess as ExecaChildProcessOrig,
+  type ExecaError,
+  type Options,
+} from "execa";
+import stream from "node:stream";
+import treeKill from "tree-kill";
+
+export type ExecaChildProcess<T extends string> = ExecaChildProcessOrig<T> & {
+  // Will be fed in real time with stdout and stderr, with timestamps.
+  log: string;
+
+  // Kill the process and all its children.
+  treekill(): Promise<void>;
+};
+
+// Pipe any process output to this stream in order to log it with timestamps.
+// See:
+// * https://stackoverflow.com/questions/21491567/how-to-implement-a-writable-stream
+// * https://blog.logrocket.com/running-commands-with-execa-in-node-js/
+class LogStream extends stream.Writable {
+  // Pass a reference to the string you want to be fed with the log.
+  constructor(logReference: { log: string }) {
+    super();
+    this.logReference = logReference;
+  }
+
+  _write(chunk: string | Buffer, encoding: string, callback: (error?: Error | null) => void) {
+    const now = new Date().toISOString();
+    const text = chunk.toString().trimEnd();
+    const lines = text.split("\n");
+    for (const line of lines) {
+      this.logReference.log += `[${now}] ${line}\n`;
+    }
+    callback();
+  }
+
+  private logReference: { log: string };
+}
+
+// Wrapper around https://github.com/sindresorhus/execa , extended with the following features:
+// - Log stdout and stderr with timestamps.
+// - Print the log on failure or timeout.
+// - Add a member `log` to the returned process, for accessing the entire log at any time, even if the command hasn't
+//   finished yet.
+// - Add a `treekill()` method to the returned process, with a more reliable implementation as the original `kill()`.
+export function execa(file: string, args?: string[], options: Options = {}): ExecaChildProcess<string> {
+  const newOptions = {
+    ...options,
+    all: true, // create a single stream for stdout and stderr
+  };
+
+  const childProcess = execaOrig(file, args, newOptions) as ExecaChildProcess<string>;
+  childProcess.log = "";
+  childProcess.all?.pipe(new LogStream(childProcess));
+  childProcess.treekill = treekill;
+  childProcess.catch(printLogOnFailure);
+  return childProcess;
+
+  async function treekill() {
+    // Unfortunately on Linux `childProcess.kill()` won't kill all the children of the process. See also
+    // https://github.com/sindresorhus/execa/pull/170#issuecomment-504143618 . To work around this, we kill all the
+    // children by using node-tree-kill.
+    const pid = childProcess.pid;
+    if (pid) {
+      await new Promise((resolve) => treeKill(pid, resolve));
+    } else {
+      childProcess.kill();
+    }
+  }
+
+  // Print the logs with timestamps on failure or timeout, but not when the process was killed.
+  function printLogOnFailure(e: ExecaError) {
+    if (e.timedOut) {
+      console.log(`'${e.command}' timed out. Output:`);
+      console.log(childProcess.log);
+    } else if (e.exitCode) {
+      console.log(`'${e.command}' failed with ${e.exitCode}. Output:`);
+      console.log(childProcess.log);
+    }
+  }
+}

--- a/packages/cli/tests/processUtils.ts
+++ b/packages/cli/tests/processUtils.ts
@@ -75,7 +75,7 @@ export function execa(file: string, args?: string[], options: Options = {}): Exe
     if (e.timedOut) {
       console.log(`'${e.command}' timed out. Output:`);
       console.log(childProcess.log);
-    } else if (e.exitCode) {
+    } else if (e.exitCode && !e.killed && !e.signal) {
       console.log(`'${e.command}' failed with ${e.exitCode}. Output:`);
       console.log(childProcess.log);
     }

--- a/packages/cli/tests/utils.ts
+++ b/packages/cli/tests/utils.ts
@@ -84,7 +84,10 @@ function execCli(context: GlobalContext, flags: string[]) {
 function runPnpmInstall(context: GlobalContext) {
   return execa("pnpm", ["install", "--prefer-offline"], {
     cwd: context.tmpdir,
-    timeout: 20000,
+
+    // Note: experience has shown that 20s may not be enough on GitHub Actions
+    // on macOS.
+    timeout: 30000,
   });
 }
 
@@ -128,7 +131,7 @@ export function prepare(flags: string[]) {
     await execCli(context, flags);
     await Promise.all([runPnpmInstall(context), initPort(context)]);
     await runDevServer(context);
-  }, 46000);
+  }, 56000);
 
   afterAll(async () => {
     await context.server?.treekill();

--- a/packages/cli/tests/utils.ts
+++ b/packages/cli/tests/utils.ts
@@ -1,12 +1,12 @@
-import { execa, type ExecaChildProcess } from "execa";
 import { afterAll, beforeAll, describe } from "vitest";
 import nodeFetch from "node-fetch";
 import { tmpdir } from "node:os";
-import { mkdtemp, rm } from "fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import http from "node:http";
 import getPort from "get-port";
-import treeKill from "tree-kill";
+
+import { execa, type ExecaChildProcess } from "./processUtils";
 
 interface GlobalContext {
   tmpdir: string;
@@ -100,12 +100,18 @@ async function runDevServer(context: GlobalContext) {
     },
   });
 
-  await Promise.race([
-    // wait for port
-    waitForLocalhost({ port: context.port, useGet: true, timeout: 20000 }),
-    // or for server to crash
-    context.server,
-  ]);
+  try {
+    await Promise.race([
+      // wait for port
+      waitForLocalhost({ port: context.port, useGet: true, timeout: 20000 }),
+      // or for server to crash
+      context.server,
+    ]);
+  } catch (e) {
+    console.log("Server didn't come up in time. Current output:");
+    console.log(context.server.log);
+    throw e;
+  }
 
   return { server: context.server, port: context.port };
 }
@@ -125,18 +131,7 @@ export function prepare(flags: string[]) {
   }, 46000);
 
   afterAll(async () => {
-    // Unfortunately on Linux `context.server?.kill()` will kill the `pnpm`
-    // process but not its children, so the dev server will keep running,
-    // leading to the recursive rm later to fail. See also
-    // https://github.com/sindresorhus/execa/pull/170#issuecomment-504143618
-    // This is also happening when running `pnpm run dev` manually in a shell:
-    // stopping it with Ctrl+C will kill the child dev server, but sending a
-    // SIGINT/SIGTERM manually won't. To work around this, we kill all the
-    // children by using node-tree-kill.
-    const pid = context.server?.pid;
-    if (pid) {
-      await new Promise((resolve) => treeKill(pid, resolve));
-    }
+    await context.server?.treekill();
     await rm(context.tmpdir, { recursive: true, force: true });
   }, 5000);
 


### PR DESCRIPTION
Simple execa wrapper adding the following features:
- Log stdout and stderr with timestamps.
- Print the log on failure or timeout.
- Add a member `log` to the returned process, for accessing the entire log at any time, even if the command hasn't finished yet.
- Add a `treekill()` method to the returned process, with a more reliable implementation as the original `kill()`.

Successful processes or processes we kill on purpose aren't logged. In other words, if test execution goes well, nothing gets logged.

Messages look like:

```
'pnpm install --prefer-offline' timed out. Output:
[2023-06-25T10:13:43.906Z] Progress: resolved 1, reused 0, downloaded 0, added 0
```
```
'pnpm instal --prefer-offline' failed with 1. Output:
[2023-06-25T10:14:43.058Z] undefined
[2023-06-25T10:14:43.082Z]  ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command failed with ENOENT: instal --prefer-offline
[2023-06-25T10:14:43.082Z] spawn instal ENOENT
[2023-06-25T10:14:43.082Z]
[2023-06-25T10:14:43.082Z] Command "instal" not found.
```

```
Server didn't come up in time. Current output:
[2023-06-25T10:10:18.033Z]
[2023-06-25T10:10:18.033Z] > my-app@0.0.26 dev /tmp/bati-yWHkIt
[2023-06-25T10:10:18.033Z] > tsx ./express-entry.ts "--port" "43579"
```

## Why?

I am/was investigating two things:

* Execution time of `pnpm install` and ways to improve it. I couldn't find any quick improvement in the end.
* Execution time of Express. When increasing test parallelism, Express takes a very long time to come up. I'm still investigating this by adding traces to `express-entry.ts`. Expect a follow-up pull request if I find anything interesting.