### PR TITLE
Fix type definition error

### DIFF
--- a/packages/boilerplates/react/files/$tsconfig.json.ts
+++ b/packages/boilerplates/react/files/$tsconfig.json.ts
@@ -6,7 +6,7 @@ export default async function getTsConfig(currentContent: MaybeContentGetter) {
 
   tsConfig.compilerOptions.jsx = "preserve";
   tsConfig.compilerOptions.jsxImportSource = "react";
-  tsConfig.compilerOptions.types = [...(tsConfig.compilerOptions.types ?? []), "vike-react/client"];
+  tsConfig.compilerOptions.types = [...(tsConfig.compilerOptions.types ?? []), "vike-react"];
 
   return tsConfig;
 }

--- a/packages/boilerplates/react/tsconfig.json
+++ b/packages/boilerplates/react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": ["../../../tsconfig.json"],
   "compilerOptions": {
-    "types": ["vite/client", "@types/node", "vike-react/client", "@batijs/core/types"],
+    "types": ["vite/client", "@types/node", "vike-react", "@batijs/core/types"],
     "jsx": "preserve",
     "jsxImportSource": "react"
   }


### PR DESCRIPTION
`Cannot find type definition file for 'vike-react/client'`

Thank you @BanDroid for spotting this!

Note: for the Solid framework, I've checked locally, `vike-solid/client` is correct. So only the React boilerplate has to be fixed.