### PR TITLE
remove classic runtime for react

### DIFF
--- a/boilerplates/react/files/$vite.config.ts.ts
+++ b/boilerplates/react/files/$vite.config.ts.ts
@@ -3,22 +3,23 @@ import { addVitePlugin, loadAsMagicast, type TransformerProps } from "@batijs/co
 export default async function getViteConfig(props: TransformerProps) {
   const mod = await loadAsMagicast(props);
 
-  const options = props.meta.BATI.has("vercel")
+  const vikeOptions = props.meta.BATI.has("vercel")
     ? {
         prerender: true,
       }
     : {};
+  // See https://github.com/batijs/bati/pull/124
+  const reactOptions = props.meta.BATI.has("vercel") && props.meta.BATI.has("hattip") ? { jsxRuntime: "classic" } : {};
 
   addVitePlugin(mod, {
     from: "@vitejs/plugin-react",
     constructor: "react",
-    // see https://github.com/vitejs/vite/discussions/5803#discussioncomment-5562200
-    options: {},
+    options: reactOptions,
   });
   addVitePlugin(mod, {
     from: "vike/plugin",
     constructor: "ssr",
-    options,
+    options: vikeOptions,
   });
 
   return mod.generate().code;

--- a/boilerplates/react/files/$vite.config.ts.ts
+++ b/boilerplates/react/files/$vite.config.ts.ts
@@ -13,7 +13,7 @@ export default async function getViteConfig(props: TransformerProps) {
     from: "@vitejs/plugin-react",
     constructor: "react",
     // see https://github.com/vitejs/vite/discussions/5803#discussioncomment-5562200
-    options: { jsxRuntime: "classic" },
+    options: {},
   });
   addVitePlugin(mod, {
     from: "vike/plugin",


### PR DESCRIPTION
the classic jsx runtime expects react import to be present in every file, but not every page or component is using something directly from react, so its unused, some of the editor has settings to remove unused imports this is where it breaks the application as it removes the unused react import. 