### PR TITLE
arrows on EnrichedTooltip

### DIFF
--- a/website/components/Features.tsx
+++ b/website/components/Features.tsx
@@ -76,12 +76,24 @@ function FeaturesGroup(props: { categories: Category[] }) {
                         {/*)}*/}
                         <div class="flex-1"></div>
                         {feature.spectrum === "beaten_path" && (
-                          <EnrichedTooltip tip={<BeatenPathTooltip />} placement="right" class="w-4 tooltip-right">
+                          <EnrichedTooltip
+                            tip={<BeatenPathTooltip />}
+                            placement="right"
+                            class="w-4"
+                            tooltipClass="w-72 lg:w-96 h-20 lg:h-16"
+                            arrow={true}
+                          >
                             <IconTrainTrack class="opacity-80"></IconTrainTrack>
                           </EnrichedTooltip>
                         )}
                         {feature.spectrum === "bleeding_edge" && (
-                          <EnrichedTooltip tip={<BleedingEdgeTooltip />} placement="right" class="w-4 tooltip-right">
+                          <EnrichedTooltip
+                            tip={<BleedingEdgeTooltip />}
+                            placement="right"
+                            class="w-4"
+                            tooltipClass="w-72 lg:w-96 h-20 lg:h-16"
+                            arrow={true}
+                          >
                             <IconAlembic class="opacity-80"></IconAlembic>
                           </EnrichedTooltip>
                         )}

--- a/website/components/Presets.tsx
+++ b/website/components/Presets.tsx
@@ -2,7 +2,7 @@ import type { CategoryLabels, Flags } from "@batijs/features";
 import { StoreContext } from "#components/Store.js";
 import clsx from "clsx";
 import { useContext } from "solid-js";
-import { Tooltip } from "./Tooltip";
+import { EnrichedTooltip } from "./Tooltip";
 
 function Preset(props: {
   title: string;
@@ -14,7 +14,7 @@ function Preset(props: {
   const { selectPreset } = useContext(StoreContext);
 
   return (
-    <Tooltip tip={props.description} class="tooltip-bottom">
+    <EnrichedTooltip tip={props.description} placement="bottom" arrow={true} tooltipClass="text-center w-64">
       <button
         type="button"
         disabled={props.disabled}
@@ -26,7 +26,7 @@ function Preset(props: {
       >
         {props.title}
       </button>
-    </Tooltip>
+    </EnrichedTooltip>
   );
 }
 
@@ -37,7 +37,7 @@ export default function Presets() {
       <Preset
         title="Frontend"
         features={["Framework", "CSS", "Linter"]}
-        description="Frontend app with Solid and Tailwind CSS"
+        description="Frontend app with a Framework and Tailwind CSS"
       />
       <Preset
         title="Full-stack"

--- a/website/components/Tooltip.tsx
+++ b/website/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { autoUpdate, flip, offset, shift, type Placement } from "@floating-ui/dom";
+import { arrow, autoUpdate, flip, offset, shift, type Placement } from "@floating-ui/dom";
 import clsx from "clsx";
 import { createSignal, onMount, type JSX } from "solid-js";
 import { useFloating } from "../lib/floating-solid";
@@ -16,15 +16,22 @@ export function Tooltip(props: { children?: JSX.Element; class?: string; tip: st
 export function EnrichedTooltip(props: {
   children: JSX.Element;
   class?: string;
+  tooltipClass?: string;
   tip: JSX.Element;
   placement: Placement;
+  arrow?: boolean;
 }) {
   const [reference, setReference] = createSignal<HTMLElement>();
   const [floating, setFloating] = createSignal<HTMLElement>();
+  const [arrowEl, setArrow] = createSignal<HTMLElement>();
+  const middlewares = [offset(16), flip(), shift()];
+  if (props.arrow) {
+    middlewares.push(arrow(() => ({ element: arrowEl()! })));
+  }
   const position = useFloating(reference, floating, {
     placement: props.placement,
     whileElementsMounted: autoUpdate,
-    middleware: [offset(16), flip(), shift()],
+    middleware: middlewares,
   });
 
   onMount(() => {
@@ -33,23 +40,31 @@ export function EnrichedTooltip(props: {
 
   return (
     <div class={clsx("dropdown dropdown-hover", props.class)}>
-      <div tabindex="0" ref={setReference}>
+      <div
+        tabindex="-1"
+        ref={setReference}
+        onclick={(e) => "blur" in e.target && typeof e.target.blur === "function" && e.target.blur()}
+      >
         {props.children}
       </div>
       <div
-        tabindex="0"
+        tabindex="-1"
         role="tooltip"
         ref={setFloating}
-        class="card compact dropdown-content z-10 shadow-md bg-neutral text-neutral-content rounded-lg flex-row items-center absolute top-o left-0 w-72 lg:w-96"
+        class={clsx(
+          "card compact dropdown-content z-10 shadow-md bg-neutral text-neutral-content rounded-lg flex-row items-center absolute",
+          props.tooltipClass,
+        )}
         style={{
           position: position.strategy,
           top: position.y ? position.y + "px" : 0,
           left: position.x ? position.x + "px" : 0,
         }}
       >
-        <div tabindex="0" class="p-2 text-sm">
+        <div tabindex="-1" class="p-2 text-sm w-full">
           {props.tip}
         </div>
+        {props.arrow && <div ref={setArrow} class="absolute bg-neutral w-2 h-2 rotate-45" style={position.arrow}></div>}
       </div>
     </div>
   );

--- a/website/lib/floating-solid.ts
+++ b/website/lib/floating-solid.ts
@@ -23,6 +23,12 @@ interface UseFloatingState extends Omit<ComputePositionReturn, "x" | "y"> {
 
 export interface UseFloatingResult extends UseFloatingState {
   update(): void;
+  arrow: {
+    left: string;
+    top: string;
+    right: string;
+    bottom: string;
+  };
 }
 
 export function useFloating<R extends ReferenceElement, F extends HTMLElement>(
@@ -117,6 +123,25 @@ export function useFloating<R extends ReferenceElement, F extends HTMLElement>(
     },
     get middlewareData() {
       return data().middlewareData;
+    },
+    get arrow() {
+      const d = data();
+      const arrow = d.middlewareData.arrow;
+
+      const staticSide = {
+        top: "bottom",
+        right: "left",
+        bottom: "top",
+        left: "right",
+      }[d.placement.split("-")[0]]!;
+
+      return {
+        left: arrow?.x != null ? `${arrow.x}px` : "",
+        top: arrow?.y != null ? `${arrow.y}px` : "",
+        right: "",
+        bottom: "",
+        [staticSide]: "-4px",
+      };
     },
     update,
   };


### PR DESCRIPTION
![image](https://github.com/batijs/bati/assets/1098371/deaa8b2d-415a-425b-8a17-56476fdf243d)

Also using `EnrichedTooltip` for presets tooltips
![image](https://github.com/batijs/bati/assets/1098371/f074d461-de85-4e78-93da-a55f18958b56)
