### PR TITLE
add compiled-css template and plugin options

### DIFF
--- a/boilerplates/compiled/files/$vite.config.ts.ts
+++ b/boilerplates/compiled/files/$vite.config.ts.ts
@@ -7,6 +7,7 @@ export default async function getViteConfig(props: TransformerProps) {
     from: "vite-plugin-compiled-react",
     constructor: "compiled",
     imported: "compiled",
+    options: { extract: true },
   });
 
   return mod.generate().code;

--- a/boilerplates/react/files/pages/index/+Page.tsx
+++ b/boilerplates/react/files/pages/index/+Page.tsx
@@ -7,6 +7,8 @@ export default function Page() {
       <h1
         //# BATI.has("tailwindcss")
         className="font-bold text-3xl pb-4"
+        //# BATI.has("compiled-css")
+        css={{ fontWeight: "bold", fontSize: "1.875rem", paddingBottom: "1rem" }}
       >
         My Vike app
       </h1>


### PR DESCRIPTION
Does the prop below `//# BATI.has("compiled-css")` need to be a single line?