### PR TITLE
update express-entry to use `headers` instead of `contentType`

### DIFF
--- a/boilerplates/express/files/express-entry.ts
+++ b/boilerplates/express/files/express-entry.ts
@@ -182,11 +182,16 @@ async function startServer() {
       : { urlOriginal: req.originalUrl };
 
     const pageContext = await renderPage(pageContextInit);
-    if (pageContext.httpResponse === null) return next();
+    const { httpResponse } = pageContext
 
-    const { statusCode, contentType } = pageContext.httpResponse;
-    res.status(statusCode).type(contentType);
-    pageContext.httpResponse.pipe(res);
+    if (!httpResponse) {
+      return next()
+    } else {
+      const { statusCode, headers } = httpResponse;
+      headers.forEach(([name, value]) => res.setHeader(name, value))
+      res.status(statusCode)
+      httpResponse.pipe(res);
+    }
   });
 
   app.listen(process.env.PORT ? parseInt(process.env.PORT) : 3000, () => {


### PR DESCRIPTION
Hi @magne4000,

This is just a minor update to use `pageContext.httpResponse.headers` instead of `pageContext.httpResponse.contentType` inside of `express-entry.ts`.

Because `pageContext.httpResponse.contentType is deprecated`.

Should we also add this ?
```ts
if (res.writeEarlyHints) res.writeEarlyHints({ link: earlyHints.map((e) => e.earlyHintLink) })
```

But, Nginx doesn't seem to support 103 Early Hints yet. https://vike.dev/nginx#early-hints

Feel free to merge or close this PR 