### PR TITLE
add a rule : `ERROR_DATA_R_SERVER` for `Data fetching`

### DIFF
--- a/packages/cli/rules.ts
+++ b/packages/cli/rules.ts
@@ -33,4 +33,7 @@ export const rulesMessages = {
   [RulesMessage.ERROR_DRIZZLE_R_SERVER]: error(
     `A ${inverse(bold("Server"))} is required when using ${inverse(bold("Drizzle"))}.`,
   ),
+  [RulesMessage.ERROR_DATA_R_SERVER]: error(
+    `A ${inverse(bold("Server"))} is required when using ${inverse(bold("Data fetching"))}.`,
+  ),
 } satisfies Record<RulesMessage, RuleMessage>;

--- a/packages/features/src/rules/enum.ts
+++ b/packages/features/src/rules/enum.ts
@@ -6,6 +6,8 @@ export enum RulesMessage {
   ERROR_COMPILED_R_REACT,
   // A Server is required when using Drizzle
   ERROR_DRIZZLE_R_SERVER,
+  // A Server is required when using Data fetching / RPC
+  ERROR_DATA_R_SERVER,
   // --- WARNING
 
   // --- INFO

--- a/packages/features/src/rules/rules.ts
+++ b/packages/features/src/rules/rules.ts
@@ -10,4 +10,5 @@ export default [
   requires(RulesMessage.ERROR_COMPILED_R_REACT, "compiled-css", ["react"]),
   includes(RulesMessage.INFO_HATTIP, "hattip"),
   requires(RulesMessage.ERROR_DRIZZLE_R_SERVER, "drizzle", ["Server"]),
+  requires(RulesMessage.ERROR_DATA_R_SERVER, "Data fetching", ["Server"]),
 ] satisfies Rule[];

--- a/packages/features/tests/rules.spec.ts
+++ b/packages/features/tests/rules.spec.ts
@@ -34,10 +34,12 @@ test("requires - extended", () => {
 
   expect(extendedRequires(prepare(["authjs"]))).toEqual(RulesMessage.ERROR_AUTH_R_SERVER);
   expect(extendedRequires(prepare(["authjs", "hattip"]))).toEqual(RulesMessage.ERROR_AUTH_R_SERVER);
-  expect(extendedRequires(prepare(["authjs", "hattip", "Framework"]))).toEqual(RulesMessage.ERROR_AUTH_R_SERVER);
+  expect(extendedRequires(prepare(["authjs", "hattip", "UI Framework"]))).toEqual(RulesMessage.ERROR_AUTH_R_SERVER);
   expect(extendedRequires(prepare(["firebase-auth"]))).toEqual(RulesMessage.ERROR_AUTH_R_SERVER);
   expect(extendedRequires(prepare(["firebase-auth", "hattip"]))).toEqual(RulesMessage.ERROR_AUTH_R_SERVER);
-  expect(extendedRequires(prepare(["firebase-auth", "hattip", "Framework"]))).toEqual(RulesMessage.ERROR_AUTH_R_SERVER);
+  expect(extendedRequires(prepare(["firebase-auth", "hattip", "UI Framework"]))).toEqual(
+    RulesMessage.ERROR_AUTH_R_SERVER,
+  );
 });
 
 test("exclusive", () => {

--- a/packages/tests/rules.local.spec.ts
+++ b/packages/tests/rules.local.spec.ts
@@ -8,7 +8,7 @@ import { execLocalBati } from "./src/exec-bati.js";
 
 const matrix = combinate([
   ["solid", "react", "vue"],
-  ["authjs", "firebase-auth", "auth0", "drizzle"],
+  ["authjs", "firebase-auth", "auth0", "drizzle", "telefunc", "trpc", "ts-rest"],
 ]);
 
 function prepareAndExecute(flags: string[]) {

--- a/website/components/RulesMessages.tsx
+++ b/website/components/RulesMessages.tsx
@@ -73,4 +73,21 @@ export const rulesMessages = {
       </span>
     );
   }),
+  [RulesMessage.ERROR_DATA_R_SERVER]: error(() => {
+    const { selectedFeatures } = useContext(StoreContext);
+
+    const selectedData = createMemo(() => selectedFeatures().filter((f) => f.category === "Data fetching")?.[0].label);
+
+    return (
+      <span class="inline-block">
+        A <span class="font-bold">Server</span> is required when using <span class="font-bold">Data fetching</span>.
+        Check{" "}
+        <ul class="list-custom list-dot">
+          <li>
+            Either pick a server (Express.js / H3 / ...) or unselect <span class="font-bold">{selectedData()}</span>
+          </li>
+        </ul>
+      </span>
+    );
+  }),
 } satisfies Record<RulesMessage, RuleMessage>;


### PR DESCRIPTION
@magne4000 

Please take a look and review this PR.

This rule applies to all data fetching currently available:

- telefunc
- trpc
- ts-rest