### PR TITLE
Smarter detection of imported dependency files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         name: Install bun
         with:
-          bun-version: "1.1.14"
+          bun-version: "1.1.17"
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,12 +66,20 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - uses: actions/cache@v4
-        name: Setup Turborepo cache
+        name: Setup Bati cache
         with:
           path: ${{ runner.temp }}/bati-cache
           key: ${{ runner.os }}-${{ matrix.node }}-bati-cache-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node }}-bati-cache-
+
+      - uses: actions/cache@v4
+        name: Setup Turborepo cache
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-${{ matrix.node }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node }}-turbo-
 
       - name: Install global dependencies
         if: matrix.os == 'ubuntu-latest'

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,3 @@
 {
-  "printWidth": 120,
-  "plugins": ["@ianvs/prettier-plugin-sort-imports"],
-  "importOrderParserPlugins": ["typescript", "jsx"],
-  "importOrderTypeScriptVersion": "5.0.0"
+  "printWidth": 120
 }

--- a/boilerplates/README.md
+++ b/boilerplates/README.md
@@ -1,7 +1,7 @@
 ### Syntax
 
 Bati uses specific syntaxes to generate its boilerplates.
-The global idea is to have templating as code, so that it is easy to write and maintain templates.
+The global idea is to have templating as code, making it is easy to write and maintain templates.
 
 <table>
 <tr>
@@ -85,6 +85,31 @@ import "./mycss";
 
 ```ts
 import "./mycss";
+```
+
+</td>
+<td>
+
+nothing
+
+</td>
+</tr>
+<tr>
+<tr>
+<td>
+
+```ts
+/*# BATI include-if-imported #*/
+
+const a = 1;
+```
+
+</td>
+<td>
+true if the file is at least imported by any other generated file
+
+```ts
+const a = 1;
 ```
 
 </td>

--- a/boilerplates/auth0/tsconfig.json
+++ b/boilerplates/auth0/tsconfig.json
@@ -3,6 +3,6 @@
     "../tsconfig.base.json"
   ],
   "compilerOptions": {
-    "types": ["@types/node", "@batijs/core/types", "@batijs/core/module"]
+    "types": ["@types/node", "@batijs/core/types"]
   }
 }

--- a/boilerplates/authjs/tsconfig.json
+++ b/boilerplates/authjs/tsconfig.json
@@ -3,6 +3,6 @@
     "../tsconfig.base.json"
   ],
   "compilerOptions": {
-    "types": ["@types/node", "@batijs/core/types", "@batijs/core/module"]
+    "types": ["@types/node", "@batijs/core/types"]
   }
 }

--- a/boilerplates/edgedb/tsconfig.json
+++ b/boilerplates/edgedb/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
-    "types": ["@types/node", "@batijs/core/types", "@batijs/core/module"]
+    "types": ["@types/node", "@batijs/core/types"]
   }
 }

--- a/boilerplates/express/tsconfig.json
+++ b/boilerplates/express/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
-    "types": ["@types/node", "@batijs/core/types", "@batijs/core/module"]
+    "types": ["@types/node", "@batijs/core/types"]
   }
 }

--- a/boilerplates/fastify/tsconfig.json
+++ b/boilerplates/fastify/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
-    "types": ["@types/node", "@batijs/core/types", "@batijs/core/module"],
+    "types": ["@types/node", "@batijs/core/types"],
     "lib": ["DOM"]
   }
 }

--- a/boilerplates/prisma/tsconfig.json
+++ b/boilerplates/prisma/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
-    "types": ["@types/node", "@batijs/core/types", "@batijs/core/module"]
+    "types": ["@types/node", "@batijs/core/types"]
   }
 }

--- a/boilerplates/react-firebase-auth/tsconfig.json
+++ b/boilerplates/react-firebase-auth/tsconfig.json
@@ -3,7 +3,7 @@
     "../tsconfig.base.json"
   ],
   "compilerOptions": {
-    "types": ["vite/client", "@types/node", "@batijs/core/types", "@batijs/core/module"],
+    "types": ["vite/client", "@types/node", "@batijs/core/types"],
     "jsx": "preserve",
     "jsxImportSource": "react",
     "lib": ["DOM", "DOM.Iterable", "ES2022"]

--- a/boilerplates/shared-server/files/server/vike-handler.ts
+++ b/boilerplates/shared-server/files/server/vike-handler.ts
@@ -1,3 +1,4 @@
+/*# BATI include-if-imported #*/
 /// <reference lib="webworker" />
 import { renderPage } from "vike/server";
 

--- a/boilerplates/solid-firebase-auth/tsconfig.json
+++ b/boilerplates/solid-firebase-auth/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "types": ["vite/client", "@types/node", "@batijs/core/types", "@batijs/core/module"],
+    "types": ["vite/client", "@types/node", "@batijs/core/types"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
     "lib": ["DOM", "DOM.Iterable", "ESNext"]

--- a/boilerplates/telefunc/tsconfig.json
+++ b/boilerplates/telefunc/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["@types/node", "@batijs/core/types", "@batijs/core/module"]
+    "types": ["@types/node", "@batijs/core/types"]
   },
   "extends": ["../tsconfig.base.json"]
 }

--- a/boilerplates/ts-rest/tsconfig.json
+++ b/boilerplates/ts-rest/tsconfig.json
@@ -3,7 +3,7 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "types": ["@batijs/core/types", "@batijs/core/module"]
+    "types": ["@batijs/core/types"]
   },
   "exclude": ["*/dist/**/*", "*/node_modules/**/*"]
 }

--- a/boilerplates/tsconfig.base.json
+++ b/boilerplates/tsconfig.base.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "types": ["@batijs/core/types", "@batijs/core/module"]
+    "types": ["@batijs/core/types"]
   },
   "exclude": ["*/dist/**/*", "*/node_modules/**/*"]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.6.0",
-    "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
     "@types/eslint__js": "^8.42.3",
     "bumpp": "^9.4.1",
     "citty": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,24 @@
     "node": ">=18",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@9.4.0"
+  "packageManager": "pnpm@9.4.0",
+  "pnpm": {
+    "overrides": {
+      "array-includes": "npm:@nolyfill/array-includes@^1",
+      "array.prototype.findlast": "npm:@nolyfill/array.prototype.findlast@^1",
+      "array.prototype.flat": "npm:@nolyfill/array.prototype.flat@^1",
+      "array.prototype.flatmap": "npm:@nolyfill/array.prototype.flatmap@^1",
+      "array.prototype.toreversed": "npm:@nolyfill/array.prototype.toreversed@^1",
+      "array.prototype.tosorted": "npm:@nolyfill/array.prototype.tosorted@^1",
+      "es-iterator-helpers": "npm:@nolyfill/es-iterator-helpers@^1",
+      "is-core-module": "npm:@nolyfill/is-core-module@^1",
+      "object.assign": "npm:@nolyfill/object.assign@^1",
+      "object.entries": "npm:@nolyfill/object.entries@^1",
+      "object.fromentries": "npm:@nolyfill/object.fromentries@^1",
+      "object.hasown": "npm:@nolyfill/object.hasown@^1",
+      "object.values": "npm:@nolyfill/object.values@^1",
+      "side-channel": "npm:@nolyfill/side-channel@^1",
+      "string.prototype.matchall": "npm:@nolyfill/string.prototype.matchall@^1"
+    }
+  }
 }

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -114,18 +114,24 @@ Please report this issue to https://github.com/batijs/bati`,
           const code = await readFile(p, { encoding: "utf-8" });
           const filepath = path.relative(source, p);
 
-          let fileContent = await transformAndFormat(code, meta, {
+          const result = await transformAndFormat(code, meta, {
             filepath,
           });
 
+          // TODO use result.context
+
+          let fileContent = result.code;
+
           if (p.endsWith(".d.ts") && targets.has(target)) {
             // Merging .d.ts files here
-            fileContent = await mergeDts({
-              fileContent,
-              target,
-              meta,
-              filepath,
-            });
+            fileContent = (
+              await mergeDts({
+                fileContent,
+                target,
+                meta,
+                filepath,
+              })
+            ).code;
           }
 
           if (fileContent) {

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -68,16 +68,69 @@ async function importTransformer(p: string) {
   return f.default as Transformer;
 }
 
+function importToPotentialTargets(imp: string) {
+  let subject = imp;
+  const ext = path.posix.extname(imp);
+  const targets: string[] = [];
+
+  if (ext.match(/^\.[jt]sx?$/)) {
+    subject = subject.replace(/^\.[jt]sx?$/, "");
+  }
+
+  if (!ext || subject !== imp) {
+    targets.push(...[".js", ".jsx", ".ts", ".tsx", ".cjs", ".mjs"].map((e) => `${subject}${e}`));
+  } else {
+    targets.push(imp);
+  }
+
+  return targets;
+}
+
 export default async function main(options: { source: string | string[]; dist: string }, meta: VikeMeta) {
   const sources = Array.isArray(options.source) ? options.source : [options.source];
   const targets = new Set<string>();
+  const allImports = new Set<string>();
+  const includeIfImported = new Map<string, () => Promise<void>>();
 
   const priorityQ = queue();
   const transformAndWriteQ = queue();
 
+  function updateAllImports(target: string, imports?: Set<string>) {
+    if (!imports) return;
+
+    for (const imp of imports.values()) {
+      const importTarget = path.posix.resolve(path.posix.dirname(target), imp);
+      const importTargets = importToPotentialTargets(importTarget);
+
+      for (const imp2 of importTargets) {
+        allImports.add(imp2);
+      }
+    }
+  }
+
+  async function triggerPendingTargets(target: string, imports?: Set<string>) {
+    if (!imports) return;
+
+    for (const imp of imports.values()) {
+      const importTarget = path.posix.resolve(path.posix.dirname(target), imp);
+      const importTargets = importToPotentialTargets(importTarget);
+      // console.log("triggerPendingTargets(targets)", importTarget, importTargets);
+
+      for (const imp2 of importTargets) {
+        if (includeIfImported.has(imp2)) {
+          const fn = includeIfImported.get(imp2)!;
+          includeIfImported.delete(imp2);
+          await fn();
+          break;
+        }
+      }
+    }
+  }
+
   for (const source of sources) {
     for await (const p of walk(source)) {
       const target = toDist(p, source, options.dist);
+      const targetAbsolute = path.resolve(target);
       const parsed = path.parse(p);
       if (parsed.name.match(reIgnoreFile)) {
         continue;
@@ -106,7 +159,6 @@ Please report this issue to https://github.com/batijs/bati`,
 
           if (fileContent !== null) {
             await safeWriteFile(target, fileContent);
-            targets.add(target);
           }
         });
       } else {
@@ -118,24 +170,26 @@ Please report this issue to https://github.com/batijs/bati`,
             filepath,
           });
 
-          // TODO use result.context
-
           let fileContent = result.code;
 
           if (p.endsWith(".d.ts") && targets.has(target)) {
             // Merging .d.ts files here
-            fileContent = (
-              await mergeDts({
-                fileContent,
-                target,
-                meta,
-                filepath,
-              })
-            ).code;
+            fileContent = await mergeDts({
+              fileContent,
+              target,
+              meta,
+              filepath,
+            });
           }
 
           if (fileContent) {
-            await safeWriteFile(target, fileContent.trimStart());
+            updateAllImports(targetAbsolute, result.context?.imports);
+            if (!result.context?.flags.has("include-if-imported") || allImports.has(targetAbsolute)) {
+              await safeWriteFile(target, fileContent.trimStart());
+              await triggerPendingTargets(targetAbsolute, result.context?.imports);
+            } else {
+              includeIfImported.set(targetAbsolute, () => safeWriteFile(target, fileContent.trimStart()));
+            }
             targets.add(target);
           }
         });
@@ -145,4 +199,11 @@ Please report this issue to https://github.com/batijs/bati`,
 
   await priorityQ.run();
   await transformAndWriteQ.run();
+
+  // Ensure all pending files are copied if necessary
+  for (const target of includeIfImported.keys()) {
+    if (allImports.has(target)) {
+      await includeIfImported.get(target)!();
+    }
+  }
 }

--- a/packages/build/src/merge-dts.ts
+++ b/packages/build/src/merge-dts.ts
@@ -50,7 +50,9 @@ export async function mergeDts({
     }
   }
 
-  return transformAndFormat(currentAst.generate().code, meta, {
+  const res = await transformAndFormat(currentAst.generate().code, meta, {
     filepath,
   });
+
+  return res.code;
 }

--- a/packages/build/tsconfig.json
+++ b/packages/build/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
-    "types": ["@types/node", "@batijs/core/types", "@batijs/core/module"]
+    "types": ["@types/node", "@batijs/core/types"]
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "sift": "^17.1.3",
     "tsup": "^8.1.0",
     "typescript": "^5.5.2",
+    "unplugin-purge-polyfills": "^0.0.4",
     "vite": "^5.3.2",
     "which-pm-runs": "^1.1.0"
   },

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "tsup";
 import esbuildBundleAllPlugin from "./esbuild-bundle-all.js";
+import { purgePolyfills } from "unplugin-purge-polyfills";
 
 export default defineConfig({
   entry: ["index.ts"],
@@ -7,7 +8,7 @@ export default defineConfig({
   outDir: "./dist",
   clean: true,
   bundle: true,
-  esbuildPlugins: [esbuildBundleAllPlugin],
+  esbuildPlugins: [esbuildBundleAllPlugin, purgePolyfills.esbuild({})],
   platform: "node",
   banner: {
     js: "#!/usr/bin/env node",

--- a/packages/compile/package.json
+++ b/packages/compile/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^18.19.14",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "unplugin-purge-polyfills": "^0.0.4"
   },
   "dependencies": {
     "esbuild": "^0.22.0",

--- a/packages/compile/tsup.config.ts
+++ b/packages/compile/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsup";
+import { purgePolyfills } from "unplugin-purge-polyfills";
 
 export default defineConfig({
   entry: ["index.ts"],
@@ -6,4 +7,5 @@ export default defineConfig({
   format: "esm",
   dts: true,
   outDir: "./dist",
+  esbuildPlugins: [purgePolyfills.esbuild({})],
 });

--- a/packages/core/module.d.ts
+++ b/packages/core/module.d.ts
@@ -1,1 +1,0 @@
-declare module "bati:*";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,18 +43,12 @@
     ".": "./dist/index.js",
     "./types": {
       "types": "./global.d.ts"
-    },
-    "./module": {
-      "types": "./module.d.ts"
     }
   },
   "typesVersions": {
     "*": {
       "types": [
         "./global.d.ts"
-      ],
-      "module": [
-        "./module.d.ts"
       ]
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "tsup": "^8.1.0",
     "tsx": "^4.16.0",
     "typescript": "^5.5.2",
+    "unplugin-purge-polyfills": "^0.0.4",
     "vitest": "^1.6.0",
     "vue-eslint-parser": "^9.4.3",
     "which": "^4.0.0"

--- a/packages/core/src/parse.ts
+++ b/packages/core/src/parse.ts
@@ -1,26 +1,34 @@
 import { formatCode } from "./format.js";
+import type { FileContext } from "./parse/linters/common.js";
 import { transform } from "./parse/linters/index.js";
 import { renderSquirrelly, tags } from "./parse/squirelly.js";
 import type { VikeMeta } from "./types.js";
 
 function guessCodeFormatters(code: string) {
   return {
-    eslint: code.includes("BATI.has") || code.includes("bati:") || code.includes("@batijs/"),
+    eslint:
+      code.includes("BATI.has") || code.includes("/*# BATI ") || code.includes("bati:") || code.includes("@batijs/"),
     squirelly: code.includes(tags[0]),
   };
 }
 
-export function transformAndFormat(code: string, meta: VikeMeta, options: { filepath: string }) {
+export async function transformAndFormat(code: string, meta: VikeMeta, options: { filepath: string }) {
   const { eslint, squirelly } = guessCodeFormatters(code);
   let c = code;
+  let context: FileContext | undefined = undefined;
   let format = false;
   if (squirelly) {
     c = renderSquirrelly(c, meta);
     format = true;
   }
   if (eslint) {
-    c = transform(c, options.filepath, meta);
+    const res = transform(c, options.filepath, meta);
+    c = res.code;
+    context = res.context;
     format = true;
   }
-  return format ? formatCode(c, options) : c;
+  return {
+    code: format ? await formatCode(c, options) : c,
+    context,
+  };
 }

--- a/packages/core/src/parse.ts
+++ b/packages/core/src/parse.ts
@@ -6,8 +6,7 @@ import type { VikeMeta } from "./types.js";
 
 function guessCodeFormatters(code: string) {
   return {
-    eslint:
-      code.includes("BATI.has") || code.includes("/*# BATI ") || code.includes("bati:") || code.includes("@batijs/"),
+    eslint: code.includes("BATI.has") || code.includes("/*# BATI ") || code.includes("@batijs/"),
     squirelly: code.includes(tags[0]),
   };
 }

--- a/packages/core/src/parse/eval.ts
+++ b/packages/core/src/parse/eval.ts
@@ -26,3 +26,14 @@ export function extractBatiConditionComment(comment: { value: string }) {
 
   return comment.value.replace(/^# /, "").trim();
 }
+
+export function extractBatiGlobalComment(comment: { value: string }) {
+  if (!comment.value.includes(" BATI ")) return null;
+
+  return comment.value
+    .replace(/^#/, "")
+    .replace(/#$/, "")
+    .replace(/\s+BATI\s+/, "")
+    .trim()
+    .split(",");
+}

--- a/packages/core/src/parse/linters/common.ts
+++ b/packages/core/src/parse/linters/common.ts
@@ -1,5 +1,9 @@
 import { Linter } from "eslint";
 
+export interface FileContext {
+  flags: Set<string>;
+}
+
 export function getLinter() {
   return new Linter({
     configType: "flat",
@@ -8,8 +12,37 @@ export function getLinter() {
 
 export function verifyAndFix(code: string, config: Linter.FlatConfig[], filename: string) {
   const linter = getLinter();
+  const context: FileContext = {
+    flags: new Set(),
+  };
 
-  const report = linter.verifyAndFix(code, config, filename);
+  const report = linter.verifyAndFix(code, config, {
+    // Extract metadata from global comment
+    postprocess(messages) {
+      const ret: Linter.LintMessage[] = [];
+
+      for (const message of messages.flat(1)) {
+        if (typeof message.message === "string") {
+          ret.push(message);
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const m: any = message.message;
+
+          if ("flags" in m && Array.isArray(m.flags)) {
+            m.flags.forEach((flag: string) => context.flags.add(flag));
+          }
+
+          ret.push({
+            ...message,
+            message: "extracted-flags",
+          });
+        }
+      }
+
+      return ret;
+    },
+    filename,
+  });
 
   if (report.messages.length > 0) {
     throw new Error(
@@ -19,5 +52,8 @@ export function verifyAndFix(code: string, config: Linter.FlatConfig[], filename
     );
   }
 
-  return report.output;
+  return {
+    code: report.output,
+    context,
+  };
 }

--- a/packages/core/src/parse/linters/linter-ts.ts
+++ b/packages/core/src/parse/linters/linter-ts.ts
@@ -6,6 +6,7 @@ import solid from "eslint-plugin-solid/configs/recommended";
 import type { VikeMeta } from "../../types.js";
 import type { Visitors } from "./types.js";
 import { visitorIfStatement } from "./visit-if-statement.js";
+import { visitorGlobalComments } from "./visitor-global-comments.js";
 import { visitorImportStatement } from "./visitor-imports.js";
 import { visitorStatementWithComments } from "./visitor-statement-with-comments.js";
 
@@ -17,7 +18,11 @@ export default function tsLinterConfig(meta: VikeMeta) {
         // @ts-ignore
         create(context) {
           const sourceCode = context.sourceCode;
+
           return {
+            Program(node) {
+              visitorGlobalComments(context, sourceCode, node);
+            },
             ImportDeclaration(node) {
               visitorImportStatement(context, node);
             },

--- a/packages/core/src/parse/linters/plugin-remove-unused-imports.ts
+++ b/packages/core/src/parse/linters/plugin-remove-unused-imports.ts
@@ -5,24 +5,23 @@ import tslint from "@typescript-eslint/eslint-plugin";
 import type { ESLint, Linter } from "eslint";
 // @ts-ignore
 import ruleComposer from "eslint-rule-composer";
+import { getExtractor } from "./common.js";
 
-const makePredicate =
-  (isImport: boolean, addFixer: any) =>
-  (problem: any, { sourceCode }: any) => {
-    const { parent } =
-      problem.node ??
-      // typescript-eslint >= 7.8 sets a range instead of a node
-      sourceCode.getNodeByRangeIndex(sourceCode.getIndexFromLoc(problem.loc.start));
-    return parent
-      ? /^Import(|Default|Namespace)Specifier$/.test(parent.type) == isImport &&
-          Object.assign(problem, addFixer?.(parent, sourceCode))
-      : problem; // If parent is null just let the composed rule handle it
-  };
+const makePredicate = (isImport: boolean, addFixer: any) => (problem: any, context: any) => {
+  const { parent } =
+    problem.node ??
+    // typescript-eslint >= 7.8 sets a range instead of a node
+    context.sourceCode.getNodeByRangeIndex(context.sourceCode.getIndexFromLoc(problem.loc.start));
+  return parent
+    ? /^Import(|Default|Namespace)Specifier$/.test(parent.type) == isImport &&
+        Object.assign(problem, addFixer?.(parent, context))
+    : problem; // If parent is null just let the composed rule handle it
+};
 
 const commaFilter = { filter: (token: any) => token.value === "," };
 const includeCommentsFilter = { includeComments: true };
 
-const unusedImportsPredicate = makePredicate(true, (parent: any, sourceCode: any) => ({
+const unusedImportsPredicate = makePredicate(true, (parent: any, context: any) => ({
   fix(fixer: any) {
     const grandParent = parent.parent;
 
@@ -30,12 +29,16 @@ const unusedImportsPredicate = makePredicate(true, (parent: any, sourceCode: any
       return null;
     }
 
+    const extractor = getExtractor(context);
+
     // Only one import
     if (grandParent.specifiers.length === 1) {
-      const nextToken = sourceCode.getTokenAfter(grandParent, includeCommentsFilter);
+      const nextToken = context.sourceCode.getTokenAfter(grandParent, includeCommentsFilter);
       const newLinesBetween = nextToken ? nextToken.loc.start.line - grandParent.loc.start.line : 0;
       const endOfReplaceRange = nextToken ? nextToken.range[0] : grandParent.range[1];
       const count = Math.max(0, newLinesBetween - 1);
+
+      extractor?.deleteImport(grandParent.source.value);
 
       return [
         fixer.remove(grandParent),
@@ -45,23 +48,23 @@ const unusedImportsPredicate = makePredicate(true, (parent: any, sourceCode: any
 
     // Not last specifier
     if (parent !== grandParent.specifiers[grandParent.specifiers.length - 1]) {
-      const comma = sourceCode.getTokenAfter(parent, commaFilter);
-      const prevNode = sourceCode.getTokenBefore(parent);
+      const comma = context.sourceCode.getTokenAfter(parent, commaFilter);
+      const prevNode = context.sourceCode.getTokenBefore(parent);
 
       return [fixer.removeRange([prevNode.range[1], parent.range[0]]), fixer.remove(parent), fixer.remove(comma)];
     }
 
     // Default export and a single normal left, ex. "import default, { package1 } from 'module';"
     if (grandParent.specifiers.filter((specifier: any) => specifier.type === "ImportSpecifier").length === 1) {
-      const start = sourceCode.getTokenBefore(parent, commaFilter);
-      const end = sourceCode.getTokenAfter(parent, {
+      const start = context.sourceCode.getTokenBefore(parent, commaFilter);
+      const end = context.sourceCode.getTokenAfter(parent, {
         filter: (token: any) => token.value === "}",
       });
 
       return fixer.removeRange([start.range[0], end.range[1]]);
     }
 
-    return fixer.removeRange([sourceCode.getTokenBefore(parent, commaFilter).range[0], parent.range[1]]);
+    return fixer.removeRange([context.sourceCode.getTokenBefore(parent, commaFilter).range[0], parent.range[1]]);
   },
 }));
 

--- a/packages/core/src/parse/linters/visitor-global-comments.ts
+++ b/packages/core/src/parse/linters/visitor-global-comments.ts
@@ -3,10 +3,7 @@ import type { Rule, SourceCode } from "eslint";
 import type * as ESTree from "estree";
 import type AST from "vue-eslint-parser/ast";
 import { extractBatiGlobalComment } from "../eval.js";
-
-export interface GlobalComment {
-  flags: string[];
-}
+import { getExtractor } from "./common.js";
 
 export function visitorGlobalComments(
   context: Rule.RuleContext,
@@ -22,14 +19,12 @@ export function visitorGlobalComments(
 
     if (flags === null || flags.length === 0) return;
 
-    const data: GlobalComment = {
-      flags: [],
-    };
+    const extractor = getExtractor(context);
 
     for (const flag of flags) {
       switch (flag) {
         case "include-if-imported":
-          data.flags.push(flag);
+          extractor?.addFlag(flag);
           break;
         default:
           context.report({
@@ -43,9 +38,7 @@ export function visitorGlobalComments(
 
     context.report({
       node: node as ESTree.Node,
-      // That way, data can be retrieved in postprocess
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      message: data as any,
+      message: "bati/global-comment",
       *fix(fixer) {
         yield fixer.remove(comment as unknown as ESTree.Node);
       },

--- a/packages/core/src/parse/linters/visitor-global-comments.ts
+++ b/packages/core/src/parse/linters/visitor-global-comments.ts
@@ -1,0 +1,54 @@
+import type { TSESTree } from "@typescript-eslint/utils";
+import type { Rule, SourceCode } from "eslint";
+import type * as ESTree from "estree";
+import type AST from "vue-eslint-parser/ast";
+import { extractBatiGlobalComment } from "../eval.js";
+
+export interface GlobalComment {
+  flags: string[];
+}
+
+export function visitorGlobalComments(
+  context: Rule.RuleContext,
+  sourceCode: SourceCode,
+  node: AST.Node | ESTree.Node | TSESTree.Node,
+) {
+  const comments = sourceCode.getAllComments();
+
+  if (comments.length > 0 && comments[0].range?.[0] === 0) {
+    const comment = comments[0];
+
+    const flags = extractBatiGlobalComment(comment);
+
+    if (flags === null || flags.length === 0) return;
+
+    const data: GlobalComment = {
+      flags: [],
+    };
+
+    for (const flag of flags) {
+      switch (flag) {
+        case "include-if-imported":
+          data.flags.push(flag);
+          break;
+        default:
+          context.report({
+            node: node as ESTree.Node,
+            message: `Unknown BATI file flag ${flag}`,
+            loc: comment.loc!,
+          });
+          return;
+      }
+    }
+
+    context.report({
+      node: node as ESTree.Node,
+      // That way, data can be retrieved in postprocess
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      message: data as any,
+      *fix(fixer) {
+        yield fixer.remove(comment as unknown as ESTree.Node);
+      },
+    });
+  }
+}

--- a/packages/core/src/parse/linters/visitor-imports.ts
+++ b/packages/core/src/parse/linters/visitor-imports.ts
@@ -5,12 +5,15 @@ import type AST from "vue-eslint-parser/ast";
 import { relative } from "../../relative.js";
 import { getExtractor } from "./common.js";
 
+export function getBatiImportMatch(subject: string) {
+  return subject.match(/^@batijs\/[^/]+\/(.+)$/);
+}
+
 export function visitorImportStatement(
   context: Rule.RuleContext,
   node: AST.ESLintImportDeclaration | ESTree.ImportDeclaration | TSESTree.ImportDeclaration,
 ) {
-  const matches = (node as TSESTree.ImportDeclaration).source.value.match(/^@batijs\/[^/]+\/(.+)$/);
-
+  const matches = getBatiImportMatch((node as TSESTree.ImportDeclaration).source.value);
   const extractor = getExtractor(context);
 
   if (matches) {

--- a/packages/core/src/parse/linters/visitor-imports.ts
+++ b/packages/core/src/parse/linters/visitor-imports.ts
@@ -3,6 +3,7 @@ import type { Rule } from "eslint";
 import type * as ESTree from "estree";
 import type AST from "vue-eslint-parser/ast";
 import { relative } from "../../relative.js";
+import { getExtractor } from "./common.js";
 
 export function visitorImportStatement(
   context: Rule.RuleContext,
@@ -10,7 +11,11 @@ export function visitorImportStatement(
 ) {
   const matches = (node as TSESTree.ImportDeclaration).source.value.match(/^@batijs\/[^/]+\/(.+)$/);
 
+  const extractor = getExtractor(context);
+
   if (matches) {
+    const newImport = relative(context.filename, matches[1]);
+    extractor?.addImport(newImport);
     context.report({
       node: node as ESTree.Node,
       message: "bati/module-imports",
@@ -20,20 +25,14 @@ export function visitorImportStatement(
             (node as TSESTree.ImportDeclaration).source.range[0] + 1,
             (node as TSESTree.ImportDeclaration).source.range[1] - 1,
           ],
-          relative(context.filename, matches[1]),
+          newImport,
         );
       },
     });
-  } else if ((node as TSESTree.ImportDeclaration).source.value.startsWith("bati:")) {
-    context.report({
-      node: node as ESTree.Node,
-      message: "bati/module-imports-generic",
-      *fix(fixer) {
-        yield fixer.removeRange([
-          (node as TSESTree.ImportDeclaration).source.range[0] + 1,
-          (node as TSESTree.ImportDeclaration).source.range[0] + "bati:".length + 1,
-        ]);
-      },
-    });
+  } else if (
+    (node as TSESTree.ImportDeclaration).source.value.startsWith("./") ||
+    (node as TSESTree.ImportDeclaration).source.value.startsWith("../")
+  ) {
+    extractor?.addImport((node as TSESTree.ImportDeclaration).source.value);
   }
 }

--- a/packages/core/tests/transform-ts.spec.ts
+++ b/packages/core/tests/transform-ts.spec.ts
@@ -333,7 +333,7 @@ export const framework = solid();`,
 });
 
 describe('rewrite "@batijs/" imports', async () => {
-  test("test", async () => {
+  test("simple", async () => {
     const filename = ctx.jsx ? "test.tsx" : "test.ts";
     const renderedOutput = await transformAndFormat(
       `import { trpc } from "@batijs/trpc/trpc/client";
@@ -351,6 +351,23 @@ export const test = trpc;`,
 
 export const test = trpc;`,
     );
+    assert.isTrue(renderedOutput.context?.imports.has("./trpc/client"));
+  });
+
+  test("With unused import", async () => {
+    const filename = ctx.jsx ? "test.tsx" : "test.ts";
+    const renderedOutput = await transformAndFormat(
+      `import { trpc } from "@batijs/trpc/trpc/client";
+
+export const test = 1;`,
+      {
+        BATI: new Set(),
+      },
+      { filepath: filename },
+    );
+
+    assert.equal(renderedOutput.code.trim(), `export const test = 1;`);
+    assert.isFalse(renderedOutput.context?.imports.has("./trpc/client"));
   });
 });
 

--- a/packages/core/tests/transform-ts.spec.ts
+++ b/packages/core/tests/transform-ts.spec.ts
@@ -332,28 +332,6 @@ export const framework = solid();`,
   );
 });
 
-describe('rewrite "bati:" imports', async () => {
-  test("test", async () => {
-    const filename = ctx.jsx ? "test.tsx" : "test.ts";
-    const renderedOutput = await transformAndFormat(
-      `import { router } from "bati:./router";
-
-export const appRouter = router();`,
-      {
-        BATI: new Set(),
-      },
-      { filepath: filename },
-    );
-
-    assert.equal(
-      renderedOutput.code.trim(),
-      `import { router } from "./router";
-
-export const appRouter = router();`,
-    );
-  });
-});
-
 describe('rewrite "@batijs/" imports', async () => {
   test("test", async () => {
     const filename = ctx.jsx ? "test.tsx" : "test.ts";

--- a/packages/core/tests/transform-vue.spec.ts
+++ b/packages/core/tests/transform-vue.spec.ts
@@ -144,29 +144,6 @@ describe("vue/script: comment", () => {
   );
 });
 
-describe('vue/script: rewrite "bati:" imports', async () => {
-  test("test", async () => {
-    const renderedOutput = await transformAndFormat(
-      `<script>
-  import { router } from "bati:./router";
-  export const appRouter = router();
-</script>`,
-      {
-        BATI: new Set(["vue"]),
-      },
-      { filepath: "test.vue" },
-    );
-
-    assert.equal(
-      renderedOutput.code.trim(),
-      `<script>
-  import { router } from "./router";
-  export const appRouter = router();
-</script>`,
-    );
-  });
-});
-
 describe('vue/script: rewrite "@batijs/" imports', async () => {
   test("test", async () => {
     const renderedOutput = await transformAndFormat(

--- a/packages/core/tests/transform-vue.spec.ts
+++ b/packages/core/tests/transform-vue.spec.ts
@@ -15,7 +15,7 @@ function testIfElse(code: string, expectedIf: string, expectedElse: string) {
       { filepath: filename },
     );
 
-    assert.equal(renderedOutput.trim(), expectedIf);
+    assert.equal(renderedOutput.code.trim(), expectedIf);
   });
 
   test("else", async () => {
@@ -27,7 +27,7 @@ function testIfElse(code: string, expectedIf: string, expectedElse: string) {
       { filepath: filename },
     );
 
-    assert.equal(renderedOutput.trim(), expectedElse);
+    assert.equal(renderedOutput.code.trim(), expectedElse);
   });
 }
 
@@ -158,7 +158,7 @@ describe('vue/script: rewrite "bati:" imports', async () => {
     );
 
     assert.equal(
-      renderedOutput.trim(),
+      renderedOutput.code.trim(),
       `<script>
   import { router } from "./router";
   export const appRouter = router();
@@ -181,7 +181,7 @@ describe('vue/script: rewrite "@batijs/" imports', async () => {
     );
 
     assert.equal(
-      renderedOutput.trim(),
+      renderedOutput.code.trim(),
       `<script>
   import { router } from "./router";
   export const appRouter = router();
@@ -238,5 +238,5 @@ test("vue formatter", async () => {
     BATI: new Set(["vue"]),
   });
 
-  assert.equal(await formatCode(renderedOutput, { filepath: "test.vue" }), code);
+  assert.equal(await formatCode(renderedOutput.code, { filepath: "test.vue" }), code);
 });

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import type { Plugin } from "esbuild";
 import { defineConfig } from "tsup";
+import { purgePolyfills } from "unplugin-purge-polyfills";
 
 const eslintFixPlugin: Plugin = {
   name: "eslint-fix-plugin",
@@ -42,7 +43,7 @@ export default defineConfig({
   outDir: "./dist",
   dts: true,
   bundle: true,
-  esbuildPlugins: [eslintFixPlugin],
+  esbuildPlugins: [eslintFixPlugin, purgePolyfills.esbuild({})],
   minify: true,
   // metafile: true,
 

--- a/packages/tests/src/exec-bati.ts
+++ b/packages/tests/src/exec-bati.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { exec } from "@batijs/tests-utils";
+import { bunExists, exec } from "@batijs/tests-utils";
 import type { GlobalContext } from "./types.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -32,7 +32,7 @@ export async function execLocalBati(context: GlobalContext, flags: string[], mon
     );
   } else {
     await exec(
-      "node",
+      bunExists ? "bun" : "node",
       [join(__dirname, "..", "..", "cli", "dist", "index.js"), ...flags.map((f) => `--${f}`), digest],
       {
         timeout: 10000,

--- a/packages/tests/src/index.ts
+++ b/packages/tests/src/index.ts
@@ -185,19 +185,12 @@ async function execTurborepo(context: GlobalContext, steps?: string[], force?: b
   const args_1 = [bunExists ? "x" : "exec", "turbo", "run"];
   const args_2 = ["--only", "--no-update-notifier", "--framework-inference", "false", "--env-mode", "loose"];
 
-  if (process.env.CI) {
-    const cacheDir = join(process.env.RUNNER_TEMP || tmpdir(), "bati-cache");
-    args_2.push("--concurrency");
-    args_2.push("2");
-    args_2.push(`--cache-dir`);
-    args_2.push(cacheDir);
-    console.log("[turborepo] Using cache dir", cacheDir);
-  } else {
-    const cacheDir = join(tmpdir(), "bati-cache");
-    args_2.push(`--cache-dir`);
-    args_2.push(cacheDir);
-    console.log("[turborepo] Using cache dir", cacheDir);
-  }
+  const cacheDir = process.env.CI
+    ? join(process.env.RUNNER_TEMP || tmpdir(), "bati-cache")
+    : join(tmpdir(), "bati-cache");
+  args_2.push(`--cache-dir`);
+  args_2.push(cacheDir);
+  console.log("[turborepo] Using cache dir", cacheDir);
 
   for (const task of ["build", "test", "lint", "typecheck"]) {
     if (steps && !steps.includes(task) && task !== "build") continue;

--- a/packages/tests/tests/FRAMEWORK.ts
+++ b/packages/tests/tests/FRAMEWORK.ts
@@ -27,7 +27,9 @@ await describeBati(({ test, expect, fetch }) => {
     expect(text).not.toContain('src="https://plausible.io');
   });
 
-  test("Bati render files are NOT present", async () => {
+  test("Bati optional files are NOT present", async () => {
     expect(existsSync(path.join(process.cwd(), "renderer", "+onRenderHtml.ts"))).toBe(false);
+    expect(existsSync(path.join(process.cwd(), "server", "vike-handler.ts"))).toBe(false);
+    expect(existsSync(path.join(process.cwd(), "server", "create-todo-handler.ts"))).toBe(false);
   });
 });

--- a/packages/tests/tests/empty.spec.ts
+++ b/packages/tests/tests/empty.spec.ts
@@ -14,4 +14,9 @@ await describeBati(({ test, expect, fetch }) => {
   test("Bati render files are present", async () => {
     expect(existsSync(path.join(process.cwd(), "renderer", "+onRenderHtml.ts"))).toBe(true);
   });
+
+  test("Bati optional files are NOT present", async () => {
+    expect(existsSync(path.join(process.cwd(), "server", "vike-handler.ts"))).toBe(false);
+    expect(existsSync(path.join(process.cwd(), "server", "create-todo-handler.ts"))).toBe(false);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@eslint/js':
         specifier: ^9.6.0
         version: 9.6.0
-      '@ianvs/prettier-plugin-sort-imports':
-        specifier: ^4.3.0
-        version: 4.3.0(@vue/compiler-sfc@3.4.31)(prettier@3.3.2)
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
@@ -2917,15 +2914,6 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
-
-  '@ianvs/prettier-plugin-sort-imports@4.3.0':
-    resolution: {integrity: sha512-OOMtUcO4J3LoL63dOKAe7bn+lSRRPeit2DqNHpx+wvBp3Grejo2PMaK4Mp1mwy8pnat64ccSgk/lBZbsAdLErw==}
-    peerDependencies:
-      '@vue/compiler-sfc': 2.7.x || 3.x
-      prettier: 2 || 3
-    peerDependenciesMeta:
-      '@vue/compiler-sfc':
-        optional: true
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
@@ -8738,20 +8726,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
-
-  '@ianvs/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.4.31)(prettier@3.3.2)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/generator': 7.24.7
-      '@babel/parser': 7.24.7
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
-      prettier: 3.3.2
-      semver: 7.6.2
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.4.31
-    transitivePeerDependencies:
-      - supports-color
 
   '@iarna/toml@2.2.5': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,23 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  array-includes: npm:@nolyfill/array-includes@^1
+  array.prototype.findlast: npm:@nolyfill/array.prototype.findlast@^1
+  array.prototype.flat: npm:@nolyfill/array.prototype.flat@^1
+  array.prototype.flatmap: npm:@nolyfill/array.prototype.flatmap@^1
+  array.prototype.toreversed: npm:@nolyfill/array.prototype.toreversed@^1
+  array.prototype.tosorted: npm:@nolyfill/array.prototype.tosorted@^1
+  es-iterator-helpers: npm:@nolyfill/es-iterator-helpers@^1
+  is-core-module: npm:@nolyfill/is-core-module@^1
+  object.assign: npm:@nolyfill/object.assign@^1
+  object.entries: npm:@nolyfill/object.entries@^1
+  object.fromentries: npm:@nolyfill/object.fromentries@^1
+  object.hasown: npm:@nolyfill/object.hasown@^1
+  object.values: npm:@nolyfill/object.values@^1
+  side-channel: npm:@nolyfill/side-channel@^1
+  string.prototype.matchall: npm:@nolyfill/string.prototype.matchall@^1
+
 importers:
 
   .:
@@ -1283,6 +1300,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
+      unplugin-purge-polyfills:
+        specifier: ^0.0.4
+        version: 0.0.4
       vite:
         specifier: ^5.3.2
         version: 5.3.2(@types/node@18.19.31)
@@ -1311,6 +1331,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
+      unplugin-purge-polyfills:
+        specifier: ^0.0.4
+        version: 0.0.4
 
   packages/core:
     devDependencies:
@@ -1371,6 +1394,9 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
+      unplugin-purge-polyfills:
+        specifier: ^0.0.4
+        version: 0.0.4
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@18.19.31)(happy-dom@14.12.3)
@@ -3012,6 +3038,78 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@nolyfill/array-includes@1.0.28':
+    resolution: {integrity: sha512-3LFZArKSQTQu//UvQXb4lBHWvhxmiZ5h2v50WIXfWb5UPNgeLpeGP8WgsfTePCpZgNlxt5JVFDdv5zLRa7cQXw==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/array.prototype.findlast@1.0.24':
+    resolution: {integrity: sha512-yFCyZLs0iNNubzYnBINcOCJAiGtusxiR2F1DnwkOB1HQbWXl/zltkDIWIXO3cJxhQdngDlmM4ysTfyAfoB297g==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/array.prototype.flat@1.0.28':
+    resolution: {integrity: sha512-bvBWaZDCWV7+jD70tJCy3Olp03Qx9svHN2KmC2j0CYvqfYRet5+iOb09nzb6QULqGrj7O8DQJ03ZQk6gih9J3g==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/array.prototype.flatmap@1.0.28':
+    resolution: {integrity: sha512-Ui/aMijqnYISchzIG0MbRiRh2DKWORJW2s//nw6rJ5jFp6x+nmFCQ5U2be3+id36VsmTxXiv+qLAHxdfXz8g8g==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/array.prototype.toreversed@1.0.27':
+    resolution: {integrity: sha512-9P4XrkD2vPKjaSUVJ66STjDn6UgMNQK7AYlAZPR1/OQVzm1xPK/Z6usWzB8o9hH83NaFxy3EqlD5wRXG0A5Mqw==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/array.prototype.tosorted@1.0.24':
+    resolution: {integrity: sha512-lVo8TVDqaslOaOvEH7iL7glu/WdlX7ZrB+7FZY4BL25hg8TLHvg3e9pxafCp8vAQ96IOL+tdgBdfeoC7qLeQYg==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/es-iterator-helpers@1.0.21':
+    resolution: {integrity: sha512-i326KeE0nhW4STobcUhkxpXzZUddedCmfh7b/IyXR9kW0CFHiNNT80C3JSEy33mUlhZtk/ezX47nymcFxyBigg==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/is-core-module@1.0.32':
+    resolution: {integrity: sha512-xmhh+wwmaCtNjY7slRZ/U+/NGjPii1dfKyYCv8iHofIbMkXFLyZTpdsIoiGbtf/JQRfQuwlohZ6B/sb2CrQbFw==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/object.assign@1.0.28':
+    resolution: {integrity: sha512-rrtnXgU2XJvUF9jFMwRbyvLdAlCIJOKtecflza4xWDom6u8UPliTOS0OQ6kvhql7/hpv9b8x9p0s467BVY58xg==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/object.entries@1.0.28':
+    resolution: {integrity: sha512-2t4PayP6Sx7Z20HJjcf8XhhPBO8/H31bwMdP0yEdDcxSXeEhl90Ibb9E3XKzSlcsGf43nXyfabHNrnfvdWE4Ng==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/object.fromentries@1.0.28':
+    resolution: {integrity: sha512-EUt70p38p+xdHDi2i8pIgw6HjrI3y9zndVhAZdEQsAvatKGKRpe3XWZRleEwYRZjkbeAG53Pz30j4tE1IJjvQQ==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/object.hasown@1.0.24':
+    resolution: {integrity: sha512-eTcdfpLttdOMPH8RGUrkKW7pS5qV3sYYDDQ7r5WpidD8QYn6WzAlQnGczuDC10kFxgQjzYpiI7UY8r63GS6wtQ==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/object.values@1.0.28':
+    resolution: {integrity: sha512-W6CdQv4Y/19aA5tenUhRELqlBoD92D4Uh1TDp5uHXD7s9zEHgcDCPCdA8ak6y4I66fR//Fir6C1mAQWv1QLnXw==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/shared@1.0.21':
+    resolution: {integrity: sha512-qDc/NoaFU23E0hhiDPeUrvWzTXIPE+RbvRQtRWSeHHNmCIgYI9HS1jKzNYNJxv4jvZ/1VmM3L6rNVxbj+LBMNA==}
+
+  '@nolyfill/shared@1.0.24':
+    resolution: {integrity: sha512-TGCpg3k5N7jj9AgU/1xFw9K1g4AC1vEE5ZFkW77oPNNLzprxT17PvFaNr/lr3BkkT5fJ5LNMntaTIq+pyWaeEA==}
+
+  '@nolyfill/shared@1.0.27':
+    resolution: {integrity: sha512-dbV1bElYaK7CJ+Vu2ihKPEiIk+c9OaXzVQaKuldHP22/uE87/fSr68ZBPXPDH+9hs/Wlpo2WVoJhx2XyhsbNaQ==}
+
+  '@nolyfill/shared@1.0.28':
+    resolution: {integrity: sha512-UJTshFMDgugBcYXGLopbL1enYpGREOEfjUMQKLPLeJqWfbfElGtYbGbUcucCENa7cicGo3M5u/DnPiZe/PYQyw==}
+
+  '@nolyfill/side-channel@1.0.29':
+    resolution: {integrity: sha512-nqk0vlqUL0wmmoPrm2HqDi0KXGy+jTNHlH/oSx7jsrh2rEApSy1mactsSUGWnhuz2ZsngJSrVHWZIaJKi3WUNA==}
+    engines: {node: '>=12.4.0'}
+
+  '@nolyfill/string.prototype.matchall@1.0.28':
+    resolution: {integrity: sha512-k74WKi7WmtRV847QWlY1ndg6XU1loeAyO9+NVoXrd7RL5lEjBtovp4CPZkifipBMBrZrZu2WwrQqkGrvLNZYpw==}
+    engines: {node: '>=12.4.0'}
+
   '@panva/asn1.js@1.0.0':
     resolution: {integrity: sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==}
     engines: {node: '>=10.13.0'}
@@ -3681,43 +3779,12 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  array-buffer-byte-length@1.0.1:
-    resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
-    engines: {node: '>= 0.4'}
-
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
-
-  array-includes@3.1.8:
-    resolution: {integrity: sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==}
-    engines: {node: '>= 0.4'}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-
-  array.prototype.findlast@1.2.5:
-    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.flat@1.3.2:
-    resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.flatmap@1.3.2:
-    resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.toreversed@1.1.2:
-    resolution: {integrity: sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==}
-
-  array.prototype.tosorted@1.1.4:
-    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
-    engines: {node: '>= 0.4'}
-
-  arraybuffer.prototype.slice@1.0.3:
-    resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
-    engines: {node: '>= 0.4'}
 
   arrify@2.0.1:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
@@ -3748,10 +3815,6 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
-
-  available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
 
   avvio@8.3.0:
     resolution: {integrity: sha512-VBVH0jubFr9LdFASy/vNtm5giTrnbVquWBhT0fyizuNK2rQ7e7ONU2plZQWUNqtE1EmxFEb+kbSkFRkstiaS9Q==}
@@ -3865,10 +3928,6 @@ packages:
   cacheable-request@7.0.4:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
-
-  call-bind@1.0.7:
-    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
-    engines: {node: '>= 0.4'}
 
   call-me-maybe@1.0.2:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
@@ -4104,18 +4163,6 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  data-view-buffer@1.0.1:
-    resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
-    engines: {node: '>= 0.4'}
-
-  data-view-byte-length@1.0.1:
-    resolution: {integrity: sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==}
-    engines: {node: '>= 0.4'}
-
-  data-view-byte-offset@1.0.0:
-    resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
-    engines: {node: '>= 0.4'}
-
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
@@ -4154,14 +4201,6 @@ packages:
   defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
-
-  define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
-
-  define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -4368,42 +4407,11 @@ packages:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  es-abstract@1.23.3:
-    resolution: {integrity: sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==}
-    engines: {node: '>= 0.4'}
-
-  es-define-property@1.0.0:
-    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-iterator-helpers@1.0.19:
-    resolution: {integrity: sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==}
-    engines: {node: '>= 0.4'}
-
   es-module-lexer@0.7.1:
     resolution: {integrity: sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==}
 
   es-module-lexer@1.5.0:
     resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
-
-  es-object-atoms@1.0.0:
-    resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.0.3:
-    resolution: {integrity: sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==}
-    engines: {node: '>= 0.4'}
-
-  es-shim-unscopables@1.0.2:
-    resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
-
-  es-to-primitive@1.2.1:
-    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
-    engines: {node: '>= 0.4'}
 
   esbuild-register@3.5.0:
     resolution: {integrity: sha512-+4G/XmakeBAsvJuDugJvtyF1x+XJT4FMocynNpxrvEBViirpfUn2PgNpCHedfWhF4WokNsO/OvMKrmJOIJsI5A==}
@@ -4720,9 +4728,6 @@ packages:
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
-  for-each@0.3.3:
-    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
-
   foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
@@ -4765,18 +4770,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  function.prototype.name@1.1.6:
-    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
-    engines: {node: '>= 0.4'}
-
   functional-red-black-tree@1.0.1:
     resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
-
-  functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
   futoin-hkdf@1.5.3:
     resolution: {integrity: sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ==}
@@ -4806,10 +4801,6 @@ packages:
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
-  get-intrinsic@1.2.4:
-    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
-    engines: {node: '>= 0.4'}
-
   get-port@7.1.0:
     resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
     engines: {node: '>=16'}
@@ -4832,10 +4823,6 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
-
-  get-symbol-description@1.0.2:
-    resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
-    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.7.5:
     resolution: {integrity: sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==}
@@ -4883,10 +4870,6 @@ packages:
     resolution: {integrity: sha512-ivatRXWwKC6ImcdKO7dOwXuXR5XFrdwo45qFwD7D0qOkEPzzJdLXC3BHceBdyrPOD3p1suPaWi4Y4NMm2D++AQ==}
     engines: {node: '>=18'}
 
-  globalthis@1.0.3:
-    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
-    engines: {node: '>= 0.4'}
-
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -4902,9 +4885,6 @@ packages:
   google-gax@4.3.4:
     resolution: {integrity: sha512-upnobdflCz9+Lq9+nOv0pm9EQ+fLhWckz6lQTgLAkLAGggIH2fl+CUj0WgczdbhQDAnA0BSNfXYHglhA/dmZpw==}
     engines: {node: '>=14'}
-
-  gopd@1.0.1:
-    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
   got@11.8.6:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
@@ -4931,9 +4911,6 @@ packages:
     resolution: {integrity: sha512-vsYlEs3E9gLwA1Hp+w3qzu+RUDFf4VTT8cyKqVICoZ2k7WM++Qyd2LwzyTi5bqMJFiIC/vNpTDYuxdreENRK/g==}
     engines: {node: '>=16.0.0'}
 
-  has-bigints@1.0.2:
-    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
-
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
@@ -4942,27 +4919,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-
-  has-proto@1.0.3:
-    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
-    engines: {node: '>= 0.4'}
-
-  has-symbols@1.0.3:
-    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
-
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
 
   hattip@0.0.33:
     resolution: {integrity: sha512-FG0IHeOdoTceFF4ta0eZ+GKEXCvqvSzLgmX3RZi3ia/OtczKn74OwjYRfyL9fBtUiyc1Z27F9daiLowfzgZ/Gg==}
@@ -5065,10 +5023,6 @@ packages:
   inline-style-parser@0.2.3:
     resolution: {integrity: sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g==}
 
-  internal-slot@1.0.7:
-    resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
-    engines: {node: '>= 0.4'}
-
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -5076,39 +5030,9 @@ packages:
   iron-webcrypto@1.1.1:
     resolution: {integrity: sha512-5xGwQUWHQSy039rFr+5q/zOmj7GP0Ypzvo34Ep+61bPIhaLduEDp/PvLGlU3awD2mzWUR0weN2vJ1mILydFPEg==}
 
-  is-array-buffer@3.0.4:
-    resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
-    engines: {node: '>= 0.4'}
-
-  is-async-function@2.0.0:
-    resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
-    engines: {node: '>= 0.4'}
-
-  is-bigint@1.0.4:
-    resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
-
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
-
-  is-boolean-object@1.1.2:
-    resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
-    engines: {node: '>= 0.4'}
-
-  is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
-
-  is-core-module@2.13.1:
-    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
-
-  is-data-view@1.0.1:
-    resolution: {integrity: sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==}
-    engines: {node: '>= 0.4'}
-
-  is-date-object@1.0.5:
-    resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
-    engines: {node: '>= 0.4'}
 
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
@@ -5118,16 +5042,9 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
-  is-finalizationregistry@1.0.2:
-    resolution: {integrity: sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-
-  is-generator-function@1.0.10:
-    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
-    engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -5136,18 +5053,6 @@ packages:
   is-html@2.0.0:
     resolution: {integrity: sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg==}
     engines: {node: '>=8'}
-
-  is-map@2.0.3:
-    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
-
-  is-negative-zero@2.0.3:
-    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
-    engines: {node: '>= 0.4'}
-
-  is-number-object@1.0.7:
-    resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
-    engines: {node: '>= 0.4'}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -5161,18 +5066,6 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-regex@1.1.4:
-    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
-    engines: {node: '>= 0.4'}
-
-  is-set@2.0.3:
-    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
-    engines: {node: '>= 0.4'}
-
-  is-shared-array-buffer@1.0.3:
-    resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
-    engines: {node: '>= 0.4'}
-
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -5185,18 +5078,6 @@ packages:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
 
-  is-string@1.0.7:
-    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
-    engines: {node: '>= 0.4'}
-
-  is-symbol@1.0.4:
-    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
-    engines: {node: '>= 0.4'}
-
-  is-typed-array@1.1.13:
-    resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
-    engines: {node: '>= 0.4'}
-
   is-unicode-supported@2.0.0:
     resolution: {integrity: sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==}
     engines: {node: '>=18'}
@@ -5205,23 +5086,9 @@ packages:
     resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==}
     engines: {node: '>=10'}
 
-  is-weakmap@2.0.2:
-    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
-    engines: {node: '>= 0.4'}
-
-  is-weakref@1.0.2:
-    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
-
-  is-weakset@2.0.3:
-    resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
-    engines: {node: '>= 0.4'}
-
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
-
-  isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isbot-fast@1.2.0:
     resolution: {integrity: sha512-twjuQzy2gKMDVfKGQyQqrx6Uy4opu/fiVUTTpdqtFsd7OQijIp5oXvb27n5EemYXaijh5fomndJt/SPRLsEdSg==}
@@ -5233,9 +5100,6 @@ packages:
   isexe@3.1.1:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
-
-  iterator.prototype@1.1.2:
-    resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
 
   itty-router@5.0.17:
     resolution: {integrity: sha512-ZHnPI0OOyTTLuNp2FdciejYaK4Wl3ZV3O0yEm8njOGggh/k/ek3BL7X2I5YsCOfc5vLhIJgj3Z4pUtLs6k9Ucg==}
@@ -5628,6 +5492,9 @@ packages:
   mlly@1.6.1:
     resolution: {integrity: sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==}
 
+  mlly@1.7.1:
+    resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -5767,33 +5634,6 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
-
-  object-inspect@1.13.1:
-    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
-
-  object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
-
-  object.assign@4.1.5:
-    resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
-    engines: {node: '>= 0.4'}
-
-  object.entries@1.1.8:
-    resolution: {integrity: sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==}
-    engines: {node: '>= 0.4'}
-
-  object.fromentries@2.0.8:
-    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
-    engines: {node: '>= 0.4'}
-
-  object.hasown@1.1.4:
-    resolution: {integrity: sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==}
-    engines: {node: '>= 0.4'}
-
-  object.values@1.2.0:
-    resolution: {integrity: sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==}
-    engines: {node: '>= 0.4'}
 
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
@@ -5970,13 +5810,12 @@ packages:
   pkg-types@1.1.0:
     resolution: {integrity: sha512-/RpmvKdxKf8uILTtoOhAgf30wYbP2Qw+L9p3Rvshx1JZVX+XQNZQFjlbmGHEGIm4CkVPlSn+NXmIM8+9oWQaSA==}
 
+  pkg-types@1.1.2:
+    resolution: {integrity: sha512-VEGf1he2DR5yowYRl0XJhWJq5ktm9gYIsH+y8sNJpHlxch7JPDaufgrsl4vYjd9hMUY8QVjoNncKbow9I7exyA==}
+
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
-
-  possible-typed-array-names@1.0.0:
-    resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
-    engines: {node: '>= 0.4'}
 
   postcss-calc@8.2.4:
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
@@ -6370,14 +6209,6 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
-  reflect.getprototypeof@1.0.6:
-    resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
-    engines: {node: '>= 0.4'}
-
-  regexp.prototype.flags@1.5.2:
-    resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
-    engines: {node: '>= 0.4'}
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -6468,16 +6299,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  safe-array-concat@1.1.2:
-    resolution: {integrity: sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==}
-    engines: {node: '>=0.4'}
-
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safe-regex-test@1.0.3:
-    resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
-    engines: {node: '>= 0.4'}
 
   safe-regex2@3.1.0:
     resolution: {integrity: sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==}
@@ -6536,14 +6359,6 @@ packages:
   set-cookie-parser@2.6.0:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
 
-  set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
-
-  set-function-name@2.0.2:
-    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
-    engines: {node: '>= 0.4'}
-
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -6557,10 +6372,6 @@ packages:
 
   shell-quote@1.8.1:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
-
-  side-channel@1.0.6:
-    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
-    engines: {node: '>= 0.4'}
 
   sift@17.1.3:
     resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
@@ -6698,21 +6509,6 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
-
-  string.prototype.matchall@4.0.11:
-    resolution: {integrity: sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trim@1.2.9:
-    resolution: {integrity: sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trimend@1.0.8:
-    resolution: {integrity: sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==}
-
-  string.prototype.trimstart@1.0.8:
-    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
-    engines: {node: '>= 0.4'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -7024,22 +6820,6 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  typed-array-buffer@1.0.2:
-    resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-byte-length@1.0.1:
-    resolution: {integrity: sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-byte-offset@1.0.2:
-    resolution: {integrity: sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-length@1.0.6:
-    resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
-    engines: {node: '>= 0.4'}
-
   typescript-eslint@7.14.1:
     resolution: {integrity: sha512-Eo1X+Y0JgGPspcANKjeR6nIqXl4VL5ldXLc15k4m9upq+eY5fhU2IueiEZL6jmHrKH8aCfbIvM/v3IrX5Hg99w==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -7060,9 +6840,6 @@ packages:
 
   ufo@1.5.3:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
-
-  unbox-primitive@1.0.2:
-    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -7091,6 +6868,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin-purge-polyfills@0.0.4:
+    resolution: {integrity: sha512-8s6XYngObhiqHjH+2tzRuaiU1LlwD6qhajuDVUHQDWrFDM1BDjeC32s0b117+a8VZSnvNI5ArWDPiYYTc5c6VQ==}
 
   unplugin-vue-markdown@0.26.2:
     resolution: {integrity: sha512-FjmhLZ+RRx7PFmfBCTwNUZLAj0Y9z0y/j79rTgYuXH9u+K6tZBFB+GpFFBm+4yMQ0la3MNCl7KHbaSvfna2bEA==}
@@ -7333,24 +7113,9 @@ packages:
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
-  which-boxed-primitive@1.0.2:
-    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
-
-  which-builtin-type@1.1.3:
-    resolution: {integrity: sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==}
-    engines: {node: '>= 0.4'}
-
-  which-collection@1.0.2:
-    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
-    engines: {node: '>= 0.4'}
-
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
-
-  which-typed-array@1.1.15:
-    resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
-    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -8867,6 +8632,70 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  '@nolyfill/array-includes@1.0.28':
+    dependencies:
+      '@nolyfill/shared': 1.0.28
+
+  '@nolyfill/array.prototype.findlast@1.0.24':
+    dependencies:
+      '@nolyfill/shared': 1.0.24
+
+  '@nolyfill/array.prototype.flat@1.0.28':
+    dependencies:
+      '@nolyfill/shared': 1.0.28
+
+  '@nolyfill/array.prototype.flatmap@1.0.28':
+    dependencies:
+      '@nolyfill/shared': 1.0.28
+
+  '@nolyfill/array.prototype.toreversed@1.0.27':
+    dependencies:
+      '@nolyfill/shared': 1.0.27
+
+  '@nolyfill/array.prototype.tosorted@1.0.24':
+    dependencies:
+      '@nolyfill/shared': 1.0.24
+
+  '@nolyfill/es-iterator-helpers@1.0.21':
+    dependencies:
+      '@nolyfill/shared': 1.0.21
+
+  '@nolyfill/is-core-module@1.0.32': {}
+
+  '@nolyfill/object.assign@1.0.28':
+    dependencies:
+      '@nolyfill/shared': 1.0.28
+
+  '@nolyfill/object.entries@1.0.28':
+    dependencies:
+      '@nolyfill/shared': 1.0.28
+
+  '@nolyfill/object.fromentries@1.0.28':
+    dependencies:
+      '@nolyfill/shared': 1.0.28
+
+  '@nolyfill/object.hasown@1.0.24':
+    dependencies:
+      '@nolyfill/shared': 1.0.24
+
+  '@nolyfill/object.values@1.0.28':
+    dependencies:
+      '@nolyfill/shared': 1.0.28
+
+  '@nolyfill/shared@1.0.21': {}
+
+  '@nolyfill/shared@1.0.24': {}
+
+  '@nolyfill/shared@1.0.27': {}
+
+  '@nolyfill/shared@1.0.28': {}
+
+  '@nolyfill/side-channel@1.0.29': {}
+
+  '@nolyfill/string.prototype.matchall@1.0.28':
+    dependencies:
+      '@nolyfill/shared': 1.0.28
+
   '@panva/asn1.js@1.0.0': {}
 
   '@panva/hkdf@1.1.1': {}
@@ -9591,72 +9420,9 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  array-buffer-byte-length@1.0.1:
-    dependencies:
-      call-bind: 1.0.7
-      is-array-buffer: 3.0.4
-
   array-flatten@1.1.1: {}
 
-  array-includes@3.1.8:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-object-atoms: 1.0.0
-      get-intrinsic: 1.2.4
-      is-string: 1.0.7
-
   array-union@2.1.0: {}
-
-  array.prototype.findlast@1.2.5:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-errors: 1.3.0
-      es-object-atoms: 1.0.0
-      es-shim-unscopables: 1.0.2
-
-  array.prototype.flat@1.3.2:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-shim-unscopables: 1.0.2
-
-  array.prototype.flatmap@1.3.2:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-shim-unscopables: 1.0.2
-
-  array.prototype.toreversed@1.1.2:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-shim-unscopables: 1.0.2
-
-  array.prototype.tosorted@1.1.4:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-errors: 1.3.0
-      es-shim-unscopables: 1.0.2
-
-  arraybuffer.prototype.slice@1.0.3:
-    dependencies:
-      array-buffer-byte-length: 1.0.1
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.4
-      is-array-buffer: 3.0.4
-      is-shared-array-buffer: 1.0.3
 
   arrify@2.0.1:
     optional: true
@@ -9688,10 +9454,6 @@ snapshots:
       picocolors: 1.0.1
       postcss: 8.4.39
       postcss-value-parser: 4.2.0
-
-  available-typed-arrays@1.0.7:
-    dependencies:
-      possible-typed-array-names: 1.0.0
 
   avvio@8.3.0:
     dependencies:
@@ -9855,14 +9617,6 @@ snapshots:
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.1
-
-  call-bind@1.0.7:
-    dependencies:
-      es-define-property: 1.0.0
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.2.4
-      set-function-length: 1.2.2
 
   call-me-maybe@1.0.2: {}
 
@@ -10111,24 +9865,6 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-view-buffer@1.0.1:
-    dependencies:
-      call-bind: 1.0.7
-      es-errors: 1.3.0
-      is-data-view: 1.0.1
-
-  data-view-byte-length@1.0.1:
-    dependencies:
-      call-bind: 1.0.7
-      es-errors: 1.3.0
-      is-data-view: 1.0.1
-
-  data-view-byte-offset@1.0.0:
-    dependencies:
-      call-bind: 1.0.7
-      es-errors: 1.3.0
-      is-data-view: 1.0.1
-
   date-fns@3.6.0: {}
 
   debug@2.6.9:
@@ -10152,18 +9888,6 @@ snapshots:
   deep-is@0.1.4: {}
 
   defer-to-connect@2.0.1: {}
-
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.0
-      es-errors: 1.3.0
-      gopd: 1.0.1
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
 
   defu@6.1.4: {}
 
@@ -10285,101 +10009,9 @@ snapshots:
 
   env-paths@3.0.0: {}
 
-  es-abstract@1.23.3:
-    dependencies:
-      array-buffer-byte-length: 1.0.1
-      arraybuffer.prototype.slice: 1.0.3
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.7
-      data-view-buffer: 1.0.1
-      data-view-byte-length: 1.0.1
-      data-view-byte-offset: 1.0.0
-      es-define-property: 1.0.0
-      es-errors: 1.3.0
-      es-object-atoms: 1.0.0
-      es-set-tostringtag: 2.0.3
-      es-to-primitive: 1.2.1
-      function.prototype.name: 1.1.6
-      get-intrinsic: 1.2.4
-      get-symbol-description: 1.0.2
-      globalthis: 1.0.3
-      gopd: 1.0.1
-      has-property-descriptors: 1.0.2
-      has-proto: 1.0.3
-      has-symbols: 1.0.3
-      hasown: 2.0.2
-      internal-slot: 1.0.7
-      is-array-buffer: 3.0.4
-      is-callable: 1.2.7
-      is-data-view: 1.0.1
-      is-negative-zero: 2.0.3
-      is-regex: 1.1.4
-      is-shared-array-buffer: 1.0.3
-      is-string: 1.0.7
-      is-typed-array: 1.1.13
-      is-weakref: 1.0.2
-      object-inspect: 1.13.1
-      object-keys: 1.1.1
-      object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.2
-      safe-array-concat: 1.1.2
-      safe-regex-test: 1.0.3
-      string.prototype.trim: 1.2.9
-      string.prototype.trimend: 1.0.8
-      string.prototype.trimstart: 1.0.8
-      typed-array-buffer: 1.0.2
-      typed-array-byte-length: 1.0.1
-      typed-array-byte-offset: 1.0.2
-      typed-array-length: 1.0.6
-      unbox-primitive: 1.0.2
-      which-typed-array: 1.1.15
-
-  es-define-property@1.0.0:
-    dependencies:
-      get-intrinsic: 1.2.4
-
-  es-errors@1.3.0: {}
-
-  es-iterator-helpers@1.0.19:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-errors: 1.3.0
-      es-set-tostringtag: 2.0.3
-      function-bind: 1.1.2
-      get-intrinsic: 1.2.4
-      globalthis: 1.0.3
-      has-property-descriptors: 1.0.2
-      has-proto: 1.0.3
-      has-symbols: 1.0.3
-      internal-slot: 1.0.7
-      iterator.prototype: 1.1.2
-      safe-array-concat: 1.1.2
-
   es-module-lexer@0.7.1: {}
 
   es-module-lexer@1.5.0: {}
-
-  es-object-atoms@1.0.0:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.0.3:
-    dependencies:
-      get-intrinsic: 1.2.4
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
-
-  es-shim-unscopables@1.0.2:
-    dependencies:
-      hasown: 2.0.2
-
-  es-to-primitive@1.2.1:
-    dependencies:
-      is-callable: 1.2.7
-      is-date-object: 1.0.5
-      is-symbol: 1.0.4
 
   esbuild-register@3.5.0(esbuild@0.19.12):
     dependencies:
@@ -10541,25 +10173,25 @@ snapshots:
 
   eslint-plugin-react@7.34.3(eslint@8.57.0):
     dependencies:
-      array-includes: 3.1.8
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.2
-      array.prototype.toreversed: 1.1.2
-      array.prototype.tosorted: 1.1.4
+      array-includes: '@nolyfill/array-includes@1.0.28'
+      array.prototype.findlast: '@nolyfill/array.prototype.findlast@1.0.24'
+      array.prototype.flatmap: '@nolyfill/array.prototype.flatmap@1.0.28'
+      array.prototype.toreversed: '@nolyfill/array.prototype.toreversed@1.0.27'
+      array.prototype.tosorted: '@nolyfill/array.prototype.tosorted@1.0.24'
       doctrine: 2.1.0
-      es-iterator-helpers: 1.0.19
+      es-iterator-helpers: '@nolyfill/es-iterator-helpers@1.0.21'
       eslint: 8.57.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
-      object.entries: 1.1.8
-      object.fromentries: 2.0.8
-      object.hasown: 1.1.4
-      object.values: 1.2.0
+      object.entries: '@nolyfill/object.entries@1.0.28'
+      object.fromentries: '@nolyfill/object.fromentries@1.0.28'
+      object.hasown: '@nolyfill/object.hasown@1.0.24'
+      object.values: '@nolyfill/object.values@1.0.28'
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
       semver: 6.3.1
-      string.prototype.matchall: 4.0.11
+      string.prototype.matchall: '@nolyfill/string.prototype.matchall@1.0.28'
 
   eslint-plugin-solid@0.14.1(eslint@8.57.0)(typescript@5.5.2):
     dependencies:
@@ -10989,10 +10621,6 @@ snapshots:
 
   flatted@3.3.1: {}
 
-  for-each@0.3.3:
-    dependencies:
-      is-callable: 1.2.7
-
   foreground-child@3.1.1:
     dependencies:
       cross-spawn: 7.0.3
@@ -11032,19 +10660,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2: {}
-
-  function.prototype.name@1.1.6:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      functions-have-names: 1.2.3
-
   functional-red-black-tree@1.0.1:
     optional: true
-
-  functions-have-names@1.2.3: {}
 
   futoin-hkdf@1.5.3: {}
 
@@ -11087,14 +10704,6 @@ snapshots:
 
   get-func-name@2.0.2: {}
 
-  get-intrinsic@1.2.4:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      has-proto: 1.0.3
-      has-symbols: 1.0.3
-      hasown: 2.0.2
-
   get-port@7.1.0: {}
 
   get-source@2.0.12:
@@ -11114,12 +10723,6 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
-
-  get-symbol-description@1.0.2:
-    dependencies:
-      call-bind: 1.0.7
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.4
 
   get-tsconfig@4.7.5:
     dependencies:
@@ -11180,10 +10783,6 @@ snapshots:
 
   globals@15.7.0: {}
 
-  globalthis@1.0.3:
-    dependencies:
-      define-properties: 1.2.1
-
   globby@11.1.0:
     dependencies:
       array-union: 2.1.0
@@ -11233,10 +10832,6 @@ snapshots:
       - encoding
       - supports-color
     optional: true
-
-  gopd@1.0.1:
-    dependencies:
-      get-intrinsic: 1.2.4
 
   got@11.8.6:
     dependencies:
@@ -11293,29 +10888,11 @@ snapshots:
       webidl-conversions: 7.0.0
       whatwg-mimetype: 3.0.0
 
-  has-bigints@1.0.2: {}
-
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.0
-
-  has-proto@1.0.3: {}
-
-  has-symbols@1.0.3: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.0.3
-
   has-unicode@2.0.1: {}
-
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
 
   hattip@0.0.33: {}
 
@@ -11414,65 +10991,19 @@ snapshots:
 
   inline-style-parser@0.2.3: {}
 
-  internal-slot@1.0.7:
-    dependencies:
-      es-errors: 1.3.0
-      hasown: 2.0.2
-      side-channel: 1.0.6
-
   ipaddr.js@1.9.1: {}
 
   iron-webcrypto@1.1.1: {}
-
-  is-array-buffer@3.0.4:
-    dependencies:
-      call-bind: 1.0.7
-      get-intrinsic: 1.2.4
-
-  is-async-function@2.0.0:
-    dependencies:
-      has-tostringtag: 1.0.2
-
-  is-bigint@1.0.4:
-    dependencies:
-      has-bigints: 1.0.2
 
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
 
-  is-boolean-object@1.1.2:
-    dependencies:
-      call-bind: 1.0.7
-      has-tostringtag: 1.0.2
-
-  is-callable@1.2.7: {}
-
-  is-core-module@2.13.1:
-    dependencies:
-      hasown: 2.0.2
-
-  is-data-view@1.0.1:
-    dependencies:
-      is-typed-array: 1.1.13
-
-  is-date-object@1.0.5:
-    dependencies:
-      has-tostringtag: 1.0.2
-
   is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
-  is-finalizationregistry@1.0.2:
-    dependencies:
-      call-bind: 1.0.7
-
   is-fullwidth-code-point@3.0.0: {}
-
-  is-generator-function@1.0.10:
-    dependencies:
-      has-tostringtag: 1.0.2
 
   is-glob@4.0.3:
     dependencies:
@@ -11482,30 +11013,11 @@ snapshots:
     dependencies:
       html-tags: 3.3.1
 
-  is-map@2.0.3: {}
-
-  is-negative-zero@2.0.3: {}
-
-  is-number-object@1.0.7:
-    dependencies:
-      has-tostringtag: 1.0.2
-
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
 
   is-plain-obj@4.1.0: {}
-
-  is-regex@1.1.4:
-    dependencies:
-      call-bind: 1.0.7
-      has-tostringtag: 1.0.2
-
-  is-set@2.0.3: {}
-
-  is-shared-array-buffer@1.0.3:
-    dependencies:
-      call-bind: 1.0.7
 
   is-stream@2.0.1: {}
 
@@ -11513,50 +11025,17 @@ snapshots:
 
   is-stream@4.0.1: {}
 
-  is-string@1.0.7:
-    dependencies:
-      has-tostringtag: 1.0.2
-
-  is-symbol@1.0.4:
-    dependencies:
-      has-symbols: 1.0.3
-
-  is-typed-array@1.1.13:
-    dependencies:
-      which-typed-array: 1.1.15
-
   is-unicode-supported@2.0.0: {}
 
   is-url-superb@4.0.0: {}
 
-  is-weakmap@2.0.2: {}
-
-  is-weakref@1.0.2:
-    dependencies:
-      call-bind: 1.0.7
-
-  is-weakset@2.0.3:
-    dependencies:
-      call-bind: 1.0.7
-      get-intrinsic: 1.2.4
-
   is-what@4.1.16: {}
-
-  isarray@2.0.5: {}
 
   isbot-fast@1.2.0: {}
 
   isexe@2.0.0: {}
 
   isexe@3.1.1: {}
-
-  iterator.prototype@1.1.2:
-    dependencies:
-      define-properties: 1.2.1
-      get-intrinsic: 1.2.4
-      has-symbols: 1.0.3
-      reflect.getprototypeof: 1.0.6
-      set-function-name: 2.0.2
 
   itty-router@5.0.17: {}
 
@@ -11643,10 +11122,10 @@ snapshots:
 
   jsx-ast-utils@3.3.5:
     dependencies:
-      array-includes: 3.1.8
-      array.prototype.flat: 1.3.2
-      object.assign: 4.1.5
-      object.values: 1.2.0
+      array-includes: '@nolyfill/array-includes@1.0.28'
+      array.prototype.flat: '@nolyfill/array.prototype.flat@1.0.28'
+      object.assign: '@nolyfill/object.assign@1.0.28'
+      object.values: '@nolyfill/object.values@1.0.28'
 
   jwa@1.4.1:
     dependencies:
@@ -11937,6 +11416,13 @@ snapshots:
       pkg-types: 1.1.0
       ufo: 1.5.3
 
+  mlly@1.7.1:
+    dependencies:
+      acorn: 8.12.0
+      pathe: 1.1.2
+      pkg-types: 1.1.2
+      ufo: 1.5.3
+
   mri@1.2.0: {}
 
   mrmime@2.0.0: {}
@@ -12045,42 +11531,6 @@ snapshots:
   object-hash@2.2.0: {}
 
   object-hash@3.0.0: {}
-
-  object-inspect@1.13.1: {}
-
-  object-keys@1.1.1: {}
-
-  object.assign@4.1.5:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      has-symbols: 1.0.3
-      object-keys: 1.1.1
-
-  object.entries@1.1.8:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-object-atoms: 1.0.0
-
-  object.fromentries@2.0.8:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-object-atoms: 1.0.0
-
-  object.hasown@1.1.4:
-    dependencies:
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-object-atoms: 1.0.0
-
-  object.values@1.2.0:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-object-atoms: 1.0.0
 
   ohash@1.1.3: {}
 
@@ -12235,11 +11685,15 @@ snapshots:
       mlly: 1.6.1
       pathe: 1.1.2
 
+  pkg-types@1.1.2:
+    dependencies:
+      confbox: 0.1.7
+      mlly: 1.7.1
+      pathe: 1.1.2
+
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
-
-  possible-typed-array-names@1.0.0: {}
 
   postcss-calc@8.2.4(postcss@8.4.39):
     dependencies:
@@ -12543,7 +11997,7 @@ snapshots:
 
   qs@6.11.0:
     dependencies:
-      side-channel: 1.0.6
+      side-channel: '@nolyfill/side-channel@1.0.29'
 
   queue-microtask@1.2.3: {}
 
@@ -12637,23 +12091,6 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  reflect.getprototypeof@1.0.6:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.4
-      globalthis: 1.0.3
-      which-builtin-type: 1.1.3
-
-  regexp.prototype.flags@1.5.2:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-errors: 1.3.0
-      set-function-name: 2.0.2
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -12674,13 +12111,13 @@ snapshots:
 
   resolve@1.22.8:
     dependencies:
-      is-core-module: 2.13.1
+      is-core-module: '@nolyfill/is-core-module@1.0.32'
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
   resolve@2.0.0-next.5:
     dependencies:
-      is-core-module: 2.13.1
+      is-core-module: '@nolyfill/is-core-module@1.0.32'
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -12755,20 +12192,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-array-concat@1.1.2:
-    dependencies:
-      call-bind: 1.0.7
-      get-intrinsic: 1.2.4
-      has-symbols: 1.0.3
-      isarray: 2.0.5
-
   safe-buffer@5.2.1: {}
-
-  safe-regex-test@1.0.3:
-    dependencies:
-      call-bind: 1.0.7
-      es-errors: 1.3.0
-      is-regex: 1.1.4
 
   safe-regex2@3.1.0:
     dependencies:
@@ -12835,22 +12259,6 @@ snapshots:
 
   set-cookie-parser@2.6.0: {}
 
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.2.4
-      gopd: 1.0.1
-      has-property-descriptors: 1.0.2
-
-  set-function-name@2.0.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      functions-have-names: 1.2.3
-      has-property-descriptors: 1.0.2
-
   setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
@@ -12860,13 +12268,6 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.1: {}
-
-  side-channel@1.0.6:
-    dependencies:
-      call-bind: 1.0.7
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.4
-      object-inspect: 1.13.1
 
   sift@17.1.3: {}
 
@@ -12993,40 +12394,6 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-
-  string.prototype.matchall@4.0.11:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-errors: 1.3.0
-      es-object-atoms: 1.0.0
-      get-intrinsic: 1.2.4
-      gopd: 1.0.1
-      has-symbols: 1.0.3
-      internal-slot: 1.0.7
-      regexp.prototype.flags: 1.5.2
-      set-function-name: 2.0.2
-      side-channel: 1.0.6
-
-  string.prototype.trim@1.2.9:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-object-atoms: 1.0.0
-
-  string.prototype.trimend@1.0.8:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-object-atoms: 1.0.0
-
-  string.prototype.trimstart@1.0.8:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-object-atoms: 1.0.0
 
   string_decoder@1.3.0:
     dependencies:
@@ -13346,38 +12713,6 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typed-array-buffer@1.0.2:
-    dependencies:
-      call-bind: 1.0.7
-      es-errors: 1.3.0
-      is-typed-array: 1.1.13
-
-  typed-array-byte-length@1.0.1:
-    dependencies:
-      call-bind: 1.0.7
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-proto: 1.0.3
-      is-typed-array: 1.1.13
-
-  typed-array-byte-offset@1.0.2:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.7
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-proto: 1.0.3
-      is-typed-array: 1.1.13
-
-  typed-array-length@1.0.6:
-    dependencies:
-      call-bind: 1.0.7
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-proto: 1.0.3
-      is-typed-array: 1.1.13
-      possible-typed-array-names: 1.0.0
-
   typescript-eslint@7.14.1(eslint@8.57.0)(typescript@5.5.2):
     dependencies:
       '@typescript-eslint/eslint-plugin': 7.14.1(@typescript-eslint/parser@7.14.1(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
@@ -13394,13 +12729,6 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.5.3: {}
-
-  unbox-primitive@1.0.2:
-    dependencies:
-      call-bind: 1.0.7
-      has-bigints: 1.0.2
-      has-symbols: 1.0.3
-      which-boxed-primitive: 1.0.2
 
   uncrypto@0.1.3: {}
 
@@ -13432,6 +12760,13 @@ snapshots:
   universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
+
+  unplugin-purge-polyfills@0.0.4:
+    dependencies:
+      defu: 6.1.4
+      magic-string: 0.30.10
+      mlly: 1.7.1
+      unplugin: 1.10.1
 
   unplugin-vue-markdown@0.26.2(rollup@4.18.0)(vite@5.3.2(@types/node@18.19.31)):
     dependencies:
@@ -13775,45 +13110,7 @@ snapshots:
       tr46: 1.0.1
       webidl-conversions: 4.0.2
 
-  which-boxed-primitive@1.0.2:
-    dependencies:
-      is-bigint: 1.0.4
-      is-boolean-object: 1.1.2
-      is-number-object: 1.0.7
-      is-string: 1.0.7
-      is-symbol: 1.0.4
-
-  which-builtin-type@1.1.3:
-    dependencies:
-      function.prototype.name: 1.1.6
-      has-tostringtag: 1.0.2
-      is-async-function: 2.0.0
-      is-date-object: 1.0.5
-      is-finalizationregistry: 1.0.2
-      is-generator-function: 1.0.10
-      is-regex: 1.1.4
-      is-weakref: 1.0.2
-      isarray: 2.0.5
-      which-boxed-primitive: 1.0.2
-      which-collection: 1.0.2
-      which-typed-array: 1.1.15
-
-  which-collection@1.0.2:
-    dependencies:
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-weakmap: 2.0.2
-      is-weakset: 2.0.3
-
   which-pm-runs@1.1.0: {}
-
-  which-typed-array@1.1.15:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.7
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:

--- a/website/lib/track.ts
+++ b/website/lib/track.ts
@@ -26,9 +26,9 @@ function generateUUID() {
 }
 
 export function track<T extends Events>(event: T["name"], data: T["data"]) {
-  const interactionId = generateUUID();
+  const interactionid = generateUUID();
   console.log({
-    interactionId,
+    interactionid,
     event,
     data,
   });
@@ -38,14 +38,14 @@ export function track<T extends Events>(event: T["name"], data: T["data"]) {
         globalThis.zaraz?.track(event, {
           flag: undefined,
           package_manager: data.package_manager,
-          interaction_id: interactionId,
+          interactionid,
         });
       }
       for (const flag of data.flags) {
         globalThis.zaraz?.track(event, {
           flag,
           package_manager: data.package_manager,
-          interaction_id: interactionId,
+          interactionid,
         });
       }
     }


### PR DESCRIPTION
Closes #275

Added a new syntax to exclude a file from being generated:
```ts
/*# BATI include-if-imported #*/

// If a file starts with the above comment, it will only be generated if it's at least imported
// by one other generated file
...
```

NB: This can be used in boilerplates using `package.json#bati.if` (but `package.json#bati.if` rules will still apply).

### Example
In the following example, `file-a.ts` is only generated if `file-b.ts` is also present.

##### boilerplates/something/files/file-a.ts
```ts
/*# BATI include-if-imported #*/

export const a = 1;
```

##### boilerplates/something-else/files/file-b.ts
```ts
import * from '@batijs/something/file-a';

...
```