### PR TITLE
Fix FormControl adaptive height in Bati Widget

### DIFF
--- a/website/components/FormControl.tsx
+++ b/website/components/FormControl.tsx
@@ -51,7 +51,7 @@ export function FormControl(props: {
           checked
           tabIndex={-1}
         />
-        <div class="tab-content bg-base-100 border-base-300 rounded-md px-5 !h-[22rem]">
+        <div class="tab-content bg-base-100 border-base-300 rounded-md px-5 pb-5">
           <div class="">
             <For each={props.categories}>
               {(category) => {


### PR DESCRIPTION
Fix FormControl adaptive height
Before:  
<img width="1185" height="1475" alt="image" src="https://github.com/user-attachments/assets/96637927-f02b-44f3-be24-6e1ade7910e2" />

After:  
<img width="1185" height="1475" alt="image" src="https://github.com/user-attachments/assets/00e95444-9e9e-4905-8720-b71abda063f8" />
